### PR TITLE
[Feat] 계정 관리 페이지 구조 구현

### DIFF
--- a/app/(routes)/mypage/PasswordForm.tsx
+++ b/app/(routes)/mypage/PasswordForm.tsx
@@ -1,0 +1,52 @@
+import { ChangeEvent, useState } from 'react';
+
+export default function PasswordForm() {
+  const [values, setValues] = useState({ current: '', new: '', repeat: '' });
+
+  const handleChangeValue = (event: ChangeEvent<HTMLInputElement>) => {
+    const { name, value } = event.target;
+    setValues((prev) => ({
+      ...prev,
+      [name]: value,
+    }));
+  };
+
+  console.log(values);
+
+  return (
+    <form>
+      <h2>비밀번호 변경</h2>
+      <fieldset>
+        <label htmlFor="current-password">현재 비밀번호</label>
+        <input
+          name="current"
+          id="current-paasword"
+          type="text"
+          onChange={handleChangeValue}
+          placeholder="비밀번호 입력"
+        />
+      </fieldset>
+      <fieldset>
+        <label htmlFor="new-password">새 비밀번호</label>
+        <input
+          name="new"
+          id="new-paasword"
+          type="text"
+          onChange={handleChangeValue}
+          placeholder="새 비밀번호 입력"
+        />
+      </fieldset>
+      <fieldset>
+        <label htmlFor="new-repeat">새 비밀번호 확인</label>
+        <input
+          name="repeat"
+          id="new-repeat"
+          type="text"
+          onChange={handleChangeValue}
+          placeholder="새 비밀번호 입력"
+        />
+      </fieldset>
+      <button type="submit">변경</button>
+    </form>
+  );
+}

--- a/app/(routes)/mypage/ProfileForm.tsx
+++ b/app/(routes)/mypage/ProfileForm.tsx
@@ -1,0 +1,51 @@
+import { ChangeEvent, useState } from 'react';
+
+interface ProfileFormProps {
+  email: string;
+  nickname: string;
+}
+
+export default function ProfileForm({ email, nickname }: ProfileFormProps) {
+  const [values, setValues] = useState({ email, nickname });
+
+  const handleChangeValue = (event: ChangeEvent<HTMLInputElement>) => {
+    const { name, value } = event.target;
+    setValues((prev) => ({
+      ...prev,
+      [name]: value,
+    }));
+  };
+
+  return (
+    <form>
+      <h2>프로필</h2>
+      <fieldset>
+        <input className="hidden" id="profile" type="file" />
+        <label htmlFor="profile">+</label>
+      </fieldset>
+      <div>
+        <fieldset>
+          <label htmlFor="email">이메일</label>
+          <input
+            id="email"
+            type="text"
+            value={values.email}
+            onChange={handleChangeValue}
+            placeholder={email}
+          />
+        </fieldset>
+        <fieldset>
+          <label htmlFor="nickname">닉네임</label>
+          <input
+            id="nickname"
+            type="text"
+            value={values.nickname}
+            onChange={handleChangeValue}
+            placeholder={nickname}
+          />
+        </fieldset>
+        <button type="submit">저장</button>
+      </div>
+    </form>
+  );
+}

--- a/app/(routes)/mypage/page.tsx
+++ b/app/(routes)/mypage/page.tsx
@@ -1,3 +1,23 @@
+'use client';
+
+import { useAuth } from '@/context/AuthContext';
+import Link from 'next/link';
+import ProfileForm from './ProfileForm';
+import PasswordForm from './PasswordForm';
+
 export default function MyPage() {
-  return <div>마이페이지</div>;
+  const { user } = useAuth();
+
+  return (
+    <div>
+      <Link href="/mydashboard">돌아가기</Link>
+
+      <ProfileForm
+        email={user?.email as string}
+        nickname={user?.nickname as string}
+      />
+
+      <PasswordForm />
+    </div>
+  );
 }


### PR DESCRIPTION
## #️⃣ 연관된 이슈

- #89 

## 🔨작업 내용

![image](https://github.com/user-attachments/assets/aa52b595-b9f1-4ee8-94ec-554accaf5d2e)

프로필 변경 폼과 비밀번호 변경 폼을 각각 의존 컴포넌트로 구현했습니다.

구현된 변경 폼은 계정 관리 페이지에서 호출해 사용됩니다.

## 💬 리뷰 요구사항(선택)

구조에 대한 구현이므로 페이지 구조 및 시멘틱이 적절한지에 대한 리뷰를 부탁드립니다.