### PR TITLE
[Feat] 프로필 변경 구현

### DIFF
--- a/app/(routes)/mypage/ImageInputField.tsx
+++ b/app/(routes)/mypage/ImageInputField.tsx
@@ -1,13 +1,11 @@
 import Image from 'next/image';
 
 interface ImageInputFieldProps {
-  initProfileImageUrl: string | null;
   profileImageUrl: string | null;
   onChange: (value: FormData | null) => void;
 }
 
 export default function ImageInputField({
-  initProfileImageUrl,
   profileImageUrl,
   onChange,
 }: ImageInputFieldProps) {
@@ -32,11 +30,11 @@ export default function ImageInputField({
         htmlFor="profile"
         className="relative flex h-40 w-40 items-center justify-center rounded-[0.4rem] bg-gray-F5F5F5 tablet:h-[11.5rem] tablet:w-[11.5rem]"
       >
-        {profileImageUrl || initProfileImageUrl ? (
+        {profileImageUrl ? (
           <Image
             fill
             sizes="100%, 100%, 100%, 100%"
-            src={profileImageUrl || (initProfileImageUrl as string)}
+            src={profileImageUrl}
             alt="프로필 이미지"
           />
         ) : (

--- a/app/(routes)/mypage/ProfileForm.tsx
+++ b/app/(routes)/mypage/ProfileForm.tsx
@@ -1,8 +1,8 @@
 import InputField from '@/_components/Auth/InputField';
-import { ChangeEvent, useEffect, useState } from 'react';
+import { ChangeEvent, FormEvent, useEffect, useState } from 'react';
 import ImageInputField from './ImageInputField';
 import useAsync from '@/_hooks/useAsync';
-import { createProfileImage } from '@/api/users.api';
+import { createProfileImage, updateUser } from '@/api/users.api';
 
 interface ProfileFormProps {
   email: string;
@@ -24,6 +24,7 @@ export default function ProfileForm({
   const [values, setValues] = useState(INIT_VALUES);
   const { data: profileDate, excute: fetchProfile } =
     useAsync(createProfileImage);
+  const { data: updateData, excute: _updateUser } = useAsync(updateUser);
 
   const handleChangeValue = (event: ChangeEvent<HTMLInputElement>) => {
     const { name, value } = event.target;
@@ -44,6 +45,14 @@ export default function ProfileForm({
     }
   };
 
+  const handleSubmit = (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    _updateUser({
+      nickname: values.nickname,
+      profileImageUrl: values.profileImageUrl,
+    });
+  };
+
   useEffect(() => {
     setValues((prev) => ({
       ...prev,
@@ -52,11 +61,18 @@ export default function ProfileForm({
   }, [profileDate]);
 
   useEffect(() => {
+    console.log(updateData);
+  }, [updateData]);
+
+  useEffect(() => {
     setValues((prev) => ({ ...prev, email, nickname }));
   }, [email, nickname]);
 
   return (
-    <form className="min-w-[18rem] rounded-lg bg-white p-4 tablet:w-[42rem] tablet:rounded-2xl tablet:p-6">
+    <form
+      className="min-w-[18rem] rounded-lg bg-white p-4 tablet:w-[42rem] tablet:rounded-2xl tablet:p-6"
+      onSubmit={handleSubmit}
+    >
       <h2 className="mb-10 text-2lg font-bold text-black-333236 tablet:mb-6 tablet:text-2xl">
         프로필
       </h2>

--- a/app/(routes)/mypage/ProfileForm.tsx
+++ b/app/(routes)/mypage/ProfileForm.tsx
@@ -3,14 +3,10 @@ import { ChangeEvent, FormEvent, useEffect, useState } from 'react';
 import ImageInputField from './ImageInputField';
 import useAsync from '@/_hooks/useAsync';
 import { createProfileImage, updateUser } from '@/api/users.api';
+import { ProfileFormProps } from './types';
+import { DEFAULT_PROFILE_VALIDATIONS, validate } from './validate';
 
-interface ProfileFormProps {
-  email: string;
-  nickname: string;
-  profileImageUrl: string | null;
-}
-
-const INIT_VALUES: ProfileFormProps = {
+const DEFAULT_VALUES: ProfileFormProps = {
   email: '',
   nickname: '',
   profileImageUrl: null,
@@ -21,31 +17,59 @@ export default function ProfileForm({
   nickname,
   profileImageUrl,
 }: ProfileFormProps) {
-  const [values, setValues] = useState(INIT_VALUES);
-  // const [isFormValid, setIsFormValid] = useState(false);
-  const { data: profileDate, excute: fetchProfile } =
-    useAsync(createProfileImage);
+  const [values, setValues] = useState(DEFAULT_VALUES);
+  const [validations, setValidations] = useState(DEFAULT_PROFILE_VALIDATIONS);
+  const [isFormValid, setIsFormValid] = useState(false);
+  const {
+    data: profileDate,
+    excute: _createProfileImage,
+    clear: claerProfile,
+  } = useAsync(createProfileImage);
   const { data: updateData, excute: _updateUser } = useAsync(updateUser);
 
+  /**
+   * 프로필 폼 입력 필드 값 변경 핸들러
+   * - 입력값 상태 관리
+   */
   const handleChangeValue = (event: ChangeEvent<HTMLInputElement>) => {
     const { name, value } = event.target;
-    setValues((prev) => ({
-      ...prev,
-      [name]: value,
-    }));
+    setValues((prev) => {
+      return {
+        ...prev,
+        [name]: value,
+      };
+    });
   };
 
+  /**
+   * 프로필 이미지 URL 생성 요청 혹은 제거 핸들러
+   * @param value
+   */
   const handleChangeProfile = (value: FormData | null) => {
     if (value) {
-      fetchProfile({ image: value });
+      _createProfileImage({ image: value });
     } else {
-      setValues((prev) => ({
-        ...prev,
-        profileImageUrl: null,
-      }));
+      claerProfile();
     }
   };
 
+  useEffect(() => {
+    setValidations((prev) => ({
+      ...prev,
+      nickname: validate.nickname(values.nickname),
+    }));
+  }, [values.nickname]);
+
+  useEffect(() => {
+    setValidations((prev) => ({
+      ...prev,
+      profileImageUrl: validate.profileImageUrl(values.profileImageUrl),
+    }));
+  }, [values.profileImageUrl]);
+
+  /**
+   * 유저 프로필 변경 요청
+   */
   const handleSubmit = (event: FormEvent<HTMLFormElement>) => {
     event.preventDefault();
     _updateUser({
@@ -54,17 +78,43 @@ export default function ProfileForm({
     });
   };
 
+  /**
+   * 폼 유효성 검사. 아래 조건을 모두 만족시키면 유효함
+   * - 프로필 URL, 닉네임 유효함
+   * - 프로필 URL과 닉네임 중 하나 이상 변경
+   */
   useEffect(() => {
+    const isValid =
+      validations.nickname.isValid && validations.profileImageUrl.isValid;
+    const isChanged =
+      profileImageUrl !== values.profileImageUrl ||
+      nickname !== values.nickname;
+    setIsFormValid(isValid && isChanged);
+  }, [validations, nickname, profileImageUrl, values]);
+
+  /**
+   * 프로필 이미지 생성 요청 성공 시
+   * - 프로필 URL 상태 관리
+   * - 프로필 URL 유효성 검사
+   */
+  useEffect(() => {
+    const next = profileDate?.profileImageUrl as string;
     setValues((prev) => ({
       ...prev,
-      profileImageUrl: profileDate?.profileImageUrl as string,
+      profileImageUrl: next,
     }));
   }, [profileDate]);
 
   useEffect(() => {
+    /**
+     * @todo useAuth에 프로필 업데이트 메서드 구현 후 적용
+     */
     console.log(updateData);
   }, [updateData]);
 
+  /**
+   * 프로필 정보 업데이트 시 반영
+   */
   useEffect(() => {
     setValues({ email, nickname, profileImageUrl });
   }, [email, nickname, profileImageUrl]);
@@ -82,7 +132,7 @@ export default function ProfileForm({
           profileImageUrl={values.profileImageUrl}
           onChange={handleChangeProfile}
         />
-        <div className="mt-10 flex flex-col gap-2 tablet:ml-10 tablet:mt-0 tablet:grow">
+        <div className="mt-10 flex flex-col gap-4 tablet:ml-10 tablet:mt-0 tablet:grow">
           <InputField
             name="email"
             type="text"
@@ -97,12 +147,13 @@ export default function ProfileForm({
             type="text"
             placeholder={nickname}
             value={values.nickname}
-            validation={{ isValid: false, message: '' }}
+            validation={validations.nickname}
             onChange={handleChangeValue}
           />
           <button
             className="w-full select-none rounded-lg border bg-violet-5534DA py-3.5 text-lg font-medium text-white disabled:bg-gray-9FA6B2"
             type="submit"
+            disabled={!isFormValid}
           >
             저장
           </button>

--- a/app/(routes)/mypage/ProfileForm.tsx
+++ b/app/(routes)/mypage/ProfileForm.tsx
@@ -53,6 +53,9 @@ export default function ProfileForm({
     }
   };
 
+  /**
+   * 닉네임 변경 시 유효성 검사
+   */
   useEffect(() => {
     setValidations((prev) => ({
       ...prev,
@@ -60,6 +63,9 @@ export default function ProfileForm({
     }));
   }, [values.nickname]);
 
+  /**
+   * 프로필 URL 변경 시 유효성 검사
+   */
   useEffect(() => {
     setValidations((prev) => ({
       ...prev,
@@ -95,7 +101,6 @@ export default function ProfileForm({
   /**
    * 프로필 이미지 생성 요청 성공 시
    * - 프로필 URL 상태 관리
-   * - 프로필 URL 유효성 검사
    */
   useEffect(() => {
     const next = profileDate?.profileImageUrl as string;

--- a/app/(routes)/mypage/ProfileForm.tsx
+++ b/app/(routes)/mypage/ProfileForm.tsx
@@ -21,7 +21,7 @@ export default function ProfileForm({
   const [validations, setValidations] = useState(DEFAULT_PROFILE_VALIDATIONS);
   const [isFormValid, setIsFormValid] = useState(false);
   const {
-    data: profileDate,
+    data: profileData,
     excute: _createProfileImage,
     clear: claerProfile,
   } = useAsync(createProfileImage);
@@ -103,12 +103,12 @@ export default function ProfileForm({
    * - 프로필 URL 상태 관리
    */
   useEffect(() => {
-    const next = profileDate?.profileImageUrl as string;
+    const next = profileData?.profileImageUrl as string;
     setValues((prev) => ({
       ...prev,
       profileImageUrl: next,
     }));
-  }, [profileDate]);
+  }, [profileData]);
 
   useEffect(() => {
     /**

--- a/app/(routes)/mypage/ProfileForm.tsx
+++ b/app/(routes)/mypage/ProfileForm.tsx
@@ -22,6 +22,7 @@ export default function ProfileForm({
   profileImageUrl,
 }: ProfileFormProps) {
   const [values, setValues] = useState(INIT_VALUES);
+  // const [isFormValid, setIsFormValid] = useState(false);
   const { data: profileDate, excute: fetchProfile } =
     useAsync(createProfileImage);
   const { data: updateData, excute: _updateUser } = useAsync(updateUser);
@@ -65,8 +66,8 @@ export default function ProfileForm({
   }, [updateData]);
 
   useEffect(() => {
-    setValues((prev) => ({ ...prev, email, nickname }));
-  }, [email, nickname]);
+    setValues({ email, nickname, profileImageUrl });
+  }, [email, nickname, profileImageUrl]);
 
   return (
     <form
@@ -78,7 +79,6 @@ export default function ProfileForm({
       </h2>
       <div className="tablet:flex">
         <ImageInputField
-          initProfileImageUrl={profileImageUrl}
           profileImageUrl={values.profileImageUrl}
           onChange={handleChangeProfile}
         />

--- a/app/(routes)/mypage/ProfileForm.tsx
+++ b/app/(routes)/mypage/ProfileForm.tsx
@@ -1,5 +1,11 @@
 import InputField from '@/_components/Auth/InputField';
-import { ChangeEvent, FormEvent, useEffect, useState } from 'react';
+import {
+  ChangeEvent,
+  FormEvent,
+  useCallback,
+  useEffect,
+  useState,
+} from 'react';
 import ImageInputField from './ImageInputField';
 import useAsync from '@/_hooks/useAsync';
 import { createProfileImage, updateUser } from '@/api/users.api';
@@ -31,27 +37,33 @@ export default function ProfileForm({
    * 프로필 폼 입력 필드 값 변경 핸들러
    * - 입력값 상태 관리
    */
-  const handleChangeValue = (event: ChangeEvent<HTMLInputElement>) => {
-    const { name, value } = event.target;
-    setValues((prev) => {
-      return {
-        ...prev,
-        [name]: value,
-      };
-    });
-  };
+  const handleChangeValue = useCallback(
+    (event: ChangeEvent<HTMLInputElement>) => {
+      const { name, value } = event.target;
+      setValues((prev) => {
+        return {
+          ...prev,
+          [name]: value,
+        };
+      });
+    },
+    [],
+  );
 
   /**
    * 프로필 이미지 URL 생성 요청 혹은 제거 핸들러
    * @param value
    */
-  const handleChangeProfile = (value: FormData | null) => {
-    if (value) {
-      _createProfileImage({ image: value });
-    } else {
-      claerProfile();
-    }
-  };
+  const handleChangeProfile = useCallback(
+    (value: FormData | null) => {
+      if (value) {
+        _createProfileImage({ image: value });
+      } else {
+        claerProfile();
+      }
+    },
+    [_createProfileImage, claerProfile],
+  );
 
   /**
    * 닉네임 변경 시 유효성 검사
@@ -76,13 +88,16 @@ export default function ProfileForm({
   /**
    * 유저 프로필 변경 요청
    */
-  const handleSubmit = (event: FormEvent<HTMLFormElement>) => {
-    event.preventDefault();
-    _updateUser({
-      nickname: values.nickname,
-      profileImageUrl: values.profileImageUrl,
-    });
-  };
+  const handleSubmit = useCallback(
+    (event: FormEvent<HTMLFormElement>) => {
+      event.preventDefault();
+      _updateUser({
+        nickname: values.nickname,
+        profileImageUrl: values.profileImageUrl,
+      });
+    },
+    [_updateUser, values],
+  );
 
   /**
    * 폼 유효성 검사. 아래 조건을 모두 만족시키면 유효함

--- a/app/(routes)/mypage/page.tsx
+++ b/app/(routes)/mypage/page.tsx
@@ -15,7 +15,7 @@ export default function MyPage() {
     <>
       <SideBar />
       <MyDashboardNavBar />
-      <div className="ml-16 bg-gray-F5F5F5 tablet:ml-40">
+      <div className="ml-16 mt-[4.5rem] bg-gray-F5F5F5 tablet:ml-40 pc:ml-72">
         <div className="flex flex-col gap-6 p-6">
           <Link
             href="/mydashboard"

--- a/app/(routes)/mypage/types.ts
+++ b/app/(routes)/mypage/types.ts
@@ -1,0 +1,16 @@
+interface ValidationType {
+  isValid: boolean;
+  message: string;
+}
+
+interface ValidationsType {
+  nickname: ValidationType;
+  profileImageUrl: ValidationType;
+}
+
+interface ProfileFormProps {
+  email: string;
+  nickname: string;
+  profileImageUrl: string | null;
+}
+export type { ValidationsType, ProfileFormProps, ValidationType };

--- a/app/(routes)/mypage/validate.ts
+++ b/app/(routes)/mypage/validate.ts
@@ -1,0 +1,40 @@
+import Validator from '@/_lib/validator';
+import { ValidationsType, ValidationType } from './types';
+
+const DEFAULT_PROFILE_VALIDATIONS: ValidationsType = {
+  nickname: { isValid: false, message: '' },
+  profileImageUrl: { isValid: false, message: '' },
+};
+
+const validate: {
+  [key: string]: (value: unknown) => ValidationType;
+} = {
+  nickname: (value: unknown) => {
+    if (typeof value === 'string') {
+      const schema = new Validator(value as string)
+        .required('닉네임을 입력해주세요')
+        .minLength(2, '닉네임을 2자 이상 입력해주세요')
+        .maxLength(10, '닉네임을 10자 이하로 입력해주세요');
+      return {
+        isValid: schema.validate(),
+        message: schema.validate() ? '' : schema.getErrors()[0],
+      };
+    }
+    return { isValid: false, message: '잘못된 형식의 입력입니다.' };
+  },
+  profileImageUrl: (value: unknown) => {
+    if (value === null) return { isValid: true, message: '' };
+
+    if (typeof value === 'string') {
+      const schema = new Validator(value).isUrl('잘못된 Url 형식입니다.');
+      return {
+        isValid: schema.validate(),
+        message: schema.validate() ? '' : schema.getErrors()[0],
+      };
+    }
+
+    return { isValid: false, message: '잘못된 형식의 입력입니다.' };
+  },
+};
+
+export { DEFAULT_PROFILE_VALIDATIONS, validate };

--- a/app/(routes)/signup/validate.ts
+++ b/app/(routes)/signup/validate.ts
@@ -56,4 +56,3 @@ function validateSchema(name: string, values: ValuesType) {
 }
 
 export { validateSchema, DEFAULT_VALIDATIONS };
-export type { ValidationType };

--- a/app/_lib/validator.ts
+++ b/app/_lib/validator.ts
@@ -15,6 +15,14 @@ export default class Validator {
     return this;
   }
 
+  isUrl(message = 'Error form isUrl'): this {
+    const regex = /^http[s]?:\/\/([\S]{3,})/i;
+    if (!regex.test(this.value)) {
+      this.errors.push(message);
+    }
+    return this;
+  }
+
   minLength(min: number, message = 'Error from minLength'): this {
     if (this.value.length < min) {
       this.errors.push(message);


### PR DESCRIPTION
## #️⃣ 연관된 이슈

- #113 

## 🔨작업 내용

### 유효성 검사 구현 `.../mypage/validate.ts`

공용 함수인 `validator.ts`를 활용해 유효성 검사 함수 `validate.ts`를 구현했습니다.

추가적으로 url 형식을 검증할 수 있는 `validator`의 메서드 `isUrl`을 추가했습니다.

```ts
  isUrl(message = 'Error form isUrl'): this {
    const regex = /^http[s]?:\/\/([\S]{3,})/i;
    if (!regex.test(this.value)) {
      this.errors.push(message);
    }
    return this;
  }
```

해당 메서드를 활용해 프로필 이미지 URL의 형식을 검사했습니다.

해당 메서드 또한 validator의 메서드 체이닝을 통해 사용할 수 있습니다.

### 프로필 변경

updateUser API를 활용해 유저 프로필 변경 기능을 구현했습니다.

하지만 user 정보를 갱신하는 기능을 포함하지 않아 

유저 정보를 변경 한 후 페이지 새로고침을 해야 변경된 정보를 확인할 수 있습니다.

새로고침을 하지 않아도 페이지가 자동 갱신되는 로직은

 차후 useAuth의 프로퍼티로 유저 정보 갱신 함수 만들어 구현하겠습니다.

### 폼 유효성 검사

프로필 변경 요청은 폼 유효성이 참일 경우에만 가능합니다.

폼은 다음 조건을 모두 만족할 때 유효합니다.
- 닉네임, 프로필 URL 유효
- 닉네임 혹은 프로필 URL 중 하나 이상 변경사항이 있을 때

두 조건 중 하나라도 만족하지 않을 경우 submit 버튼이 disabled가 됩니다.

## 💬 리뷰 요구사항

상태값 변경에 따라 순차적으로 로직을 적용하려다 보니 useEffect의 사용이 많습니다. 혹시 개선 방법을 아시는 분은 언제든 말씀 주시길 바랍니다.

**예시 | 프로필 이미지 업로드**
1. 이미지 입력
2. 이미지를 FormData 변환
3. FormData로 createProfileImage 요청
4. 응답으로 받은 URL 상태값 저장
5. 상태값 변경 시 유효성 검사
6. 폼 유효성 검사


