### PR TITLE
feat: 대쉬보드 컨테이너 반응형 레이아웃 구현

### DIFF
--- a/app/(routes)/dashboard/[dashboardId]/Dashboard.tsx
+++ b/app/(routes)/dashboard/[dashboardId]/Dashboard.tsx
@@ -204,7 +204,7 @@ export default function DashBoard({ dashBoard }: { dashBoard: DashboardType }) {
         onDragOver={handleDragOver}
         onDragEnd={handleDragEnd}
       >
-        <div className="mt-[70px] flex w-fit justify-center rounded border border-gray-400">
+        <div className="mt-[70px] flex w-full mobile:flex-col pc:flex-row pc:justify-between">
           {Object.keys(itemGroups).map((itemGroup) => (
             <Droppable
               key={itemGroup}

--- a/app/(routes)/dashboard/[dashboardId]/Droppable.tsx
+++ b/app/(routes)/dashboard/[dashboardId]/Droppable.tsx
@@ -12,14 +12,20 @@ interface DroppableProps {
 
 export default function Droppable({ id, items, title }: DroppableProps) {
   const { setNodeRef } = useDroppable({ id });
+
   return (
     <SortableContext id={id} items={items} strategy={rectSortingStrategy}>
-      <ul className="flex-col space-y-2" ref={setNodeRef}>
-        <p>{title}</p>
-        {items.map((item) => (
-          <SortableItem key={item.id} id={item.id} />
-        ))}
-      </ul>
+      <div>
+        <p className="mb-4 text-lg font-bold">{title}</p>
+        <ul
+          ref={setNodeRef}
+          className="scrollbar-stable grid w-full auto-cols-[90%] grid-flow-col rounded-lg p-4 mobile:gap-14 mobile:overflow-x-auto tablet:max-h-[200px] tablet:grid-flow-row tablet:gap-4 tablet:overflow-y-auto pc:max-h-full"
+        >
+          {items.map((item) => (
+            <SortableItem key={item.id} id={item.id} />
+          ))}
+        </ul>
+      </div>
     </SortableContext>
   );
 }

--- a/app/(routes)/dashboard/[dashboardId]/Item.tsx
+++ b/app/(routes)/dashboard/[dashboardId]/Item.tsx
@@ -8,7 +8,7 @@ interface ItemsProps {
 export function Item({ id, dragOverlay }: ItemsProps) {
   return (
     <div
-      className={`item ${dragOverlay ? 'cursor-grabbing' : 'cursor-grab'} rounded border-2 border-gray-200`}
+      className={`item h-[70px] w-[200px] mobile:w-full ${dragOverlay ? 'cursor-grabbing' : 'cursor-grab'} rounded border-2 border-gray-200 bg-gray-100 p-4`}
     >
       할 일 카드 {id}
     </div>

--- a/app/(routes)/dashboard/[dashboardId]/SortableItem.tsx
+++ b/app/(routes)/dashboard/[dashboardId]/SortableItem.tsx
@@ -9,7 +9,7 @@ export default function SortableItem({ id }: { id: UniqueIdentifier }) {
 
   return (
     <li
-      className={`transform transition-all ${isDragging ? 'opacity-50' : 'opacity-100'}`}
+      className={`w-full transform transition-all ${isDragging ? 'opacity-50' : 'opacity-100'}`}
       style={{
         transform: transform ? CSS.Transform.toString(transform) : undefined,
       }}

--- a/app/_styles/globals.css
+++ b/app/_styles/globals.css
@@ -22,7 +22,7 @@
   /* 부드러운 렌더링을 위한 속성 */
   body {
     font-family: 'Pretendard Variable', sans-serif;
-    
+
     @apply min-h-screen bg-white text-gray-900;
     -webkit-font-smoothing: antialiased;
     -moz-osx-font-smoothing: grayscale;
@@ -35,3 +35,9 @@
   }
 }
 
+@layer utilities {
+  /* 스크롤바 안정성을 위한 유틸리티 클래스 */
+  .scrollbar-stable {
+    scrollbar-gutter: stable;
+  }
+}


### PR DESCRIPTION
- Mobile: 컨테이너 1열, 카드 1행 횡 스크롤
- Tablet: 컨테이너 1열, 카드 1열 종 스크롤
- PC: 컨테이너 1행, 카드 1열 모든 카드(무한 스크롤 예정)

## #️⃣ 연관된 이슈

- #117 

## 🔨작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

![image](https://github.com/user-attachments/assets/5319a724-1ae6-4677-9bfe-5d64764e67da)

![image](https://github.com/user-attachments/assets/f974f5f9-6bfe-45bd-9770-9f4e1b2d2126)

![image](https://github.com/user-attachments/assets/7d7484e8-f9df-4189-ae13-9498cfe617ba)


- [x] Mobile : 컨테이너 세로 1열, 카드 1개 출력(횡 스크롤)
- [x] Tablet : 컨테이너 세로 1열, 카드 2개 출력(종 스크롤)
- [x] PC : 컨테이너 가로 1열, 카드 페이지 맞추어 출력(종 스크롤)

## 💬 리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요

- 위 작업들은 우선 멘토링 때 얘기했던 방향대로 구현한 작업들입니다.
- 피그마에선 각 디바이스별 레이아웃에 카드 하나, 또는 두 개만 출력 되고 있어서 우선 x, y축 방향으로의 스크롤로 구현했습니다.
- 현재의 브라우저 기본 스크롤 바도 스타일 커스텀이 가능합니다.
- `global.css`에 추가한 부분은 스크롤 바가 생길 때, 스크롤 바가 생기면서 차지하는 공간을 모든 컨테이너에 미리 확보하여 크기 변동이 없도록 하는 속성입니다.

- 디바이스면 카드 출력 방식에 대해선 추후 논의를 통해 수정이 필요하다면 수정하겠습니다.

pc버전에서는 각 컨테이너별 무한스크롤을 구현할 예정입니다.
