### PR TITLE
[Refactor] 나의 대시보드 리팩토링

### DIFF
--- a/app/(routes)/mydashboard/DashboardList.tsx
+++ b/app/(routes)/mydashboard/DashboardList.tsx
@@ -1,13 +1,9 @@
 'use client';
 
 import Image from 'next/image';
-import { useEffect, useState } from 'react';
-import { getDashboardList } from '@/api/dashboards.api';
-import useAsync from '@/_hooks/useAsync';
 import Link from 'next/link';
-import CreateDashboardModal from './CreateDashboardModal';
 
-interface Dashboard {
+interface DashboardType {
   id: number;
   title: string;
   color: string;
@@ -17,57 +13,36 @@ interface Dashboard {
   createdByMe: boolean;
 }
 
-const SIZE = 5;
+interface DashboardListProps {
+  dashboardList: DashboardType[];
+  totalPages: number;
+  currentPage: number;
+  onPageChange: (page: number) => void;
+  onOpenCreateModal: () => void;
+}
 
-export default function DashboardList() {
-  const [isModalOpen, setIsModalOpen] = useState<boolean>(false);
-  const [page, setPage] = useState(1);
-  const {
-    data,
-    excute: fetchDashboards,
-    loading,
-  } = useAsync(
-    async ({ page }: { page: number }) =>
-      await getDashboardList({
-        navigationMethod: 'pagination',
-        page,
-        size: SIZE,
-      }),
-  );
-
-  useEffect(() => {
-    fetchDashboards({ page });
-  }, [page]);
-
-  const totalPages = data?.totalCount ? Math.ceil(data.totalCount / SIZE) : 0;
-
+export default function DashboardList({
+  dashboardList,
+  totalPages,
+  currentPage,
+  onPageChange,
+  onOpenCreateModal,
+}: DashboardListProps) {
   const handleNextPage = () => {
-    if (page < totalPages) {
-      setPage((prevPage) => prevPage + 1);
-    }
+    if (currentPage < totalPages) onPageChange(currentPage + 1);
   };
 
   const handlePreviousPage = () => {
-    if (page > 1) {
-      setPage((prevPage) => prevPage - 1);
-    }
-  };
-
-  const handleOpenCreateModal = () => {
-    setIsModalOpen(true);
-  };
-
-  const handleCloseCreateModal = () => {
-    setIsModalOpen(false);
+    if (currentPage > 1) onPageChange(currentPage - 1);
   };
 
   return (
     <div className="p-4 pl-[5.5rem] pt-[5.25rem] tablet:pl-[12.5rem] tablet:pt-[6.875rem] pc:pl-[21.25rem] pc:pt-28">
       <div className="max-w-5xl">
-        <div className="grid grid-cols-1 grid-rows-6 gap-4 tablet:grid-cols-2 tablet:grid-rows-3 pc:grid-cols-3 pc:grid-rows-2">
+        <div className="pc:rows-2 grid grid-cols-1 grid-rows-6 gap-4 tablet:grid-cols-2 tablet:grid-rows-3 pc:grid-cols-3">
           <button
             type="button"
-            onClick={handleOpenCreateModal}
+            onClick={onOpenCreateModal}
             className="flex items-center justify-center gap-3 rounded-lg border border-gray-D9D9D9 px-14 py-5 hover:cursor-pointer"
           >
             <p className="font-pretendard text-md font-semibold text-black-333236 tablet:text-lg">
@@ -80,46 +55,47 @@ export default function DashboardList() {
               height={22}
             />
           </button>
-          {!loading &&
-            data?.dashboards.map((dashboard: Dashboard) => (
-              <Link
-                href={`/dashboard/${dashboard.id}`}
-                key={dashboard.id}
-                className="flex w-full items-center justify-between gap-3 rounded-lg border border-gray-D9D9D9 px-5 py-5"
-              >
-                <div className="flex w-11/12 items-center gap-3 pc:gap-4">
-                  <div
-                    className="h-2 w-2 rounded-full"
-                    style={{ backgroundColor: dashboard.color }}
-                  ></div>
-                  <p className="truncate font-pretendard text-md font-semibold text-black-333236 tablet:text-base">
-                    {dashboard.title}
-                  </p>
-                  {dashboard.createdByMe && (
-                    <Image
-                      width={18}
-                      height={18}
-                      src="/images/icon/ic-crown.svg"
-                      alt="crown"
-                    />
-                  )}
-                </div>
-                <Image
-                  width={18}
-                  height={18}
-                  src="/images/icon/ic-blackarrow.svg"
-                  alt="arrow"
-                />
-              </Link>
-            ))}
-          {loading && <div>Loading...</div>}
+
+          {dashboardList.map((dashboard) => (
+            <Link
+              href={`/dashboard/${dashboard.id}`}
+              key={dashboard.id}
+              className="flex w-full items-center justify-between gap-3 rounded-lg border border-gray-D9D9D9 px-5 py-5"
+            >
+              <div className="flex w-11/12 items-center gap-3 pc:gap-4">
+                <div
+                  className="h-2 w-2 rounded-full"
+                  style={{ backgroundColor: dashboard.color }}
+                ></div>
+                <p className="truncate font-pretendard text-md font-semibold text-black-333236 tablet:text-base">
+                  {dashboard.title}
+                </p>
+                {dashboard.createdByMe && (
+                  <Image
+                    width={18}
+                    height={18}
+                    src="/images/icon/ic-crown.svg"
+                    alt="crown"
+                  />
+                )}
+              </div>
+              <Image
+                width={18}
+                height={18}
+                src="/images/icon/ic-blackarrow.svg"
+                alt="arrow"
+              />
+            </Link>
+          ))}
         </div>
         <div className="mt-4 flex items-center justify-end gap-4 pc:mt-3">
-          <div className="font-pretendard text-xs font-normal text-black-333236 tablet:text-md">{`${totalPages} 페이지 중 ${page} `}</div>
+          <div className="font-pretendard text-xs font-normal text-black-333236 tablet:text-md">
+            {`${totalPages} 페이지 중 ${currentPage}`}
+          </div>
           <div>
             <button
               onClick={handlePreviousPage}
-              disabled={page === 1}
+              disabled={currentPage === 1}
               className="rounded-md border border-gray-D9D9D9 px-2.5 py-2.5 tablet:px-3 tablet:py-3"
             >
               <Image
@@ -131,7 +107,7 @@ export default function DashboardList() {
             </button>
             <button
               onClick={handleNextPage}
-              disabled={data?.dashboards.length !== SIZE}
+              disabled={currentPage === totalPages}
               className="rounded-md border border-gray-D9D9D9 px-2.5 py-2.5 tablet:px-3 tablet:py-3"
             >
               <Image
@@ -144,7 +120,6 @@ export default function DashboardList() {
           </div>
         </div>
       </div>
-      {isModalOpen && <CreateDashboardModal onClose={handleCloseCreateModal} />}
     </div>
   );
 }

--- a/app/(routes)/mydashboard/DashboardList.tsx
+++ b/app/(routes)/mydashboard/DashboardList.tsx
@@ -1,17 +1,8 @@
 'use client';
 
+import { DashboardType } from '@/_types/dashboards.type';
 import Image from 'next/image';
 import Link from 'next/link';
-
-interface DashboardType {
-  id: number;
-  title: string;
-  color: string;
-  userId: number;
-  createdAt: string;
-  updatedAt: string;
-  createdByMe: boolean;
-}
 
 interface DashboardListProps {
   dashboardList: DashboardType[];

--- a/app/(routes)/mydashboard/DashboardList.tsx
+++ b/app/(routes)/mydashboard/DashboardList.tsx
@@ -55,7 +55,7 @@ export default function DashboardList({
             >
               <div className="flex w-11/12 items-center gap-3 pc:gap-4">
                 <div
-                  className="h-2 w-2 rounded-full"
+                  className="h-2 w-2 shrink-0 rounded-full"
                   style={{ backgroundColor: dashboard.color }}
                 ></div>
                 <p className="truncate font-pretendard text-md font-semibold text-black-333236 tablet:text-base">

--- a/app/(routes)/mydashboard/InvitationsDashboard.tsx
+++ b/app/(routes)/mydashboard/InvitationsDashboard.tsx
@@ -10,7 +10,13 @@ import SearchBar from './SearchBar';
 
 const INVITATION_SIZE = 10;
 
-export default function InvitationsDashboard() {
+interface InvitationsDashboardProps {
+  onAcceptInvitation: () => void;
+}
+
+export default function InvitationsDashboard({
+  onAcceptInvitation,
+}: InvitationsDashboardProps) {
   const [offset, setOffset] = useState(0);
   const [invitations, setInvitations] = useState<InvitationType[]>([]);
   const [hasMore, setHasMore] = useState(true);
@@ -100,6 +106,7 @@ export default function InvitationsDashboard() {
     setInvitations((prev) =>
       prev.filter((invitation) => invitation.id !== invitationId),
     );
+    onAcceptInvitation();
   };
 
   const handleClickReject = async (invitationId: number) => {

--- a/app/(routes)/mydashboard/page.tsx
+++ b/app/(routes)/mydashboard/page.tsx
@@ -8,16 +8,7 @@ import InvitationsDashboard from './InvitationsDashboard';
 import useAsync from '@/_hooks/useAsync';
 import { getDashboardList } from '@/api/dashboards.api';
 import CreateDashboardModal from './CreateDashboardModal';
-
-interface DashboardType {
-  id: number;
-  title: string;
-  color: string;
-  userId: number;
-  createdAt: string;
-  updatedAt: string;
-  createdByMe: boolean;
-}
+import { DashboardType } from '@/_types/dashboards.type';
 
 export default function MyDashboardPage() {
   const [dashboardList, setDashboardList] = useState<DashboardType[]>([]);

--- a/app/(routes)/mydashboard/page.tsx
+++ b/app/(routes)/mydashboard/page.tsx
@@ -1,16 +1,73 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import NavBar from '@/_components/Navbar/NavBar';
 import Sidebar from '@/_components/Sidebar/SideBar';
 import DashboardList from './DashboardList';
-import NavBar from '@/_components/Navbar/NavBar';
 import InvitationsDashboard from './InvitationsDashboard';
+import useAsync from '@/_hooks/useAsync';
+import { getDashboardList } from '@/api/dashboards.api';
+import CreateDashboardModal from './CreateDashboardModal';
 
+interface DashboardType {
+  id: number;
+  title: string;
+  color: string;
+  userId: number;
+  createdAt: string;
+  updatedAt: string;
+  createdByMe: boolean;
+}
 
-export default function myDashBoardPage() {
+export default function MyDashboardPage() {
+  const [dashboardList, setDashboardList] = useState<DashboardType[]>([]);
+  const [totalPages, setTotalPages] = useState(1);
+  const [currentPage, setCurrentPage] = useState(1);
+  const [isModalOpen, setIsModalOpen] = useState(false);
+
+  const { excute: fetchDashboards } = useAsync(async (page: number) => {
+    const data = await getDashboardList({
+      navigationMethod: 'pagination',
+      page,
+      size: 5,
+    });
+    setDashboardList(data.dashboards);
+    setTotalPages(Math.ceil(data.totalCount / 5));
+  });
+
+  useEffect(() => {
+    fetchDashboards(currentPage);
+  }, [currentPage]);
+
+  const handlePageChange = (page: number) => {
+    setCurrentPage(page);
+  };
+
+  const handleOpenCreateModal = () => {
+    setIsModalOpen(true);
+  };
+
+  const handleCloseCreateModal = () => {
+    setIsModalOpen(false);
+  };
+
+  const handleAcceptInvitation = () => {
+    fetchDashboards(currentPage);
+  };
+
   return (
     <div>
       <NavBar type="mydashboard" />
       <Sidebar />
-      <DashboardList />
-      <InvitationsDashboard />
+      <DashboardList
+        dashboardList={dashboardList}
+        totalPages={totalPages}
+        currentPage={currentPage}
+        onPageChange={handlePageChange}
+        onOpenCreateModal={handleOpenCreateModal}
+      />
+      <InvitationsDashboard onAcceptInvitation={handleAcceptInvitation} />
+      {isModalOpen && <CreateDashboardModal onClose={handleCloseCreateModal} />}
     </div>
   );
 }


### PR DESCRIPTION
## #️⃣ 연관된 이슈

- #132 

## 🔨작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

### 대시보드 제목에 따른 원 깨짐 현상 수정

- 멘토링 시간에 발견했던 제목 길이에 따른 원 깨짐 현상을 수정했습니다.

![image](https://github.com/user-attachments/assets/bbf69e31-a2e5-419e-bab1-48a8852d6eba)


### 대시보드 리스트 상위페이지에서 관리 후 props로 이용해 초대 수락 반영

- mydashboard 폴더의 `page.tsx` 파일에서 대시보드에 대한 상태관리를 하고 하위 페이지에 전달

### DashboardType '/_types'폴더에서 이용하도록 수정

- 기존에 interface를 이용했던 DashboardType을 `'/_types'`폴더에 정의된 타입을 이용하도록 수정

## 💬 리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요

<!-- ex) 추가되었는데 이부분 꼭 참고해주세요. -->
