### PR TITLE
[Feat] useAuth 리팩터링 및 계정 정보 변경 시 유저 정보 갱신 로직 구현

### DIFF
--- a/app/(routes)/login/page.tsx
+++ b/app/(routes)/login/page.tsx
@@ -27,8 +27,8 @@ export default function LoginPage() {
   const {
     user,
     login,
-    loadingLogin: loading,
-    loginErrorMessage: errorMessage,
+    loading,
+    errorMessage,
   } = useAuth();
   const router = useRouter();
 
@@ -60,12 +60,12 @@ export default function LoginPage() {
   };
 
   useEffect(() => {
-    if (errorMessage) {
+    if (errorMessage.login) {
       setShowModal(true);
     } else {
       setShowModal(false);
     }
-  }, [errorMessage]);
+  }, [errorMessage.login]);
 
   useEffect(() => {
     validateForm();
@@ -81,7 +81,7 @@ export default function LoginPage() {
   return (
     <>
       {showModal && (
-        <Modal text={errorMessage as string} onClick={handleCloseModal} />
+        <Modal text={errorMessage.login as string} onClick={handleCloseModal} />
       )}
       <div className="mx-auto w-full max-w-xs pb-8 pt-20 tablet:max-w-lg tablet:pt-52">
         <AuthHeader text="오늘도 만나서 반가워요!" />
@@ -104,7 +104,7 @@ export default function LoginPage() {
           <button
             className="w-full select-none rounded-lg border bg-violet-5534DA py-3.5 text-lg font-medium text-white disabled:bg-gray-9FA6B2"
             type="submit"
-            disabled={!isFormValid || loading}
+            disabled={!isFormValid || loading.login}
           >
             로그인
           </button>

--- a/app/(routes)/mypage/PasswordForm.tsx
+++ b/app/(routes)/mypage/PasswordForm.tsx
@@ -14,7 +14,7 @@ const DEFAUTL_VALUES = {
   confirmed: '',
 };
 
-export default function PasswordForm() {
+export default function PasswordForm({ update }: { update: () => void }) {
   const [values, setValues] = useState(DEFAUTL_VALUES);
   const [validations, setValidations] = useState(DEFAULT_PASSWORD_VALIDATIONS);
   const [isFormValid, setIsFormValid] = useState(false);
@@ -69,8 +69,8 @@ export default function PasswordForm() {
   }, [validations]);
 
   useEffect(() => {
-    console.log(updateData);
-  }, [updateData]);
+    update();
+  }, [updateData, update]);
 
   return (
     <form

--- a/app/(routes)/mypage/ProfileForm.tsx
+++ b/app/(routes)/mypage/ProfileForm.tsx
@@ -3,10 +3,10 @@ import { ChangeEvent, FormEvent, useEffect, useState } from 'react';
 import ImageInputField from './ImageInputField';
 import useAsync from '@/_hooks/useAsync';
 import { createProfileImage, updateUser } from '@/api/users.api';
-import { ProfileFormProps } from './types';
+import { ProfileFormProps, ProfileValuesType } from './types';
 import { DEFAULT_PROFILE_VALIDATIONS, validate } from './validate';
 
-const DEFAULT_VALUES: ProfileFormProps = {
+const DEFAULT_VALUES: ProfileValuesType = {
   email: '',
   nickname: '',
   profileImageUrl: null,
@@ -16,6 +16,7 @@ export default function ProfileForm({
   email,
   nickname,
   profileImageUrl,
+  update,
 }: ProfileFormProps) {
   const [values, setValues] = useState(DEFAULT_VALUES);
   const [validations, setValidations] = useState(DEFAULT_PROFILE_VALIDATIONS);
@@ -114,11 +115,8 @@ export default function ProfileForm({
    * 프로필 정보 업데이트 시 반영
    */
   useEffect(() => {
-    /**
-     * @todo useAuth에 프로필 업데이트 메서드 구현 후 적용
-     */
-    console.log(updateData);
-  }, [updateData]);
+    update();
+  }, [updateData, update]);
 
   /**
    * 프로필 정보 업데이트 시 반영

--- a/app/(routes)/mypage/page.tsx
+++ b/app/(routes)/mypage/page.tsx
@@ -11,8 +11,6 @@ import SideBar from '@/_components/Sidebar/SideBar';
 export default function MyPage() {
   const { user, update } = useAuth();
 
-  console.log('mypage');
-
   return (
     <>
       <SideBar />

--- a/app/(routes)/mypage/page.tsx
+++ b/app/(routes)/mypage/page.tsx
@@ -9,7 +9,9 @@ import MyDashboardNavBar from '@/_components/Navbar/MyDashboardNavBar';
 import SideBar from '@/_components/Sidebar/SideBar';
 
 export default function MyPage() {
-  const { user } = useAuth();
+  const { user, update } = useAuth();
+
+  console.log('mypage');
 
   return (
     <>
@@ -30,8 +32,9 @@ export default function MyPage() {
             email={user?.email as string}
             nickname={user?.nickname as string}
             profileImageUrl={user?.profileImageUrl as string | null}
+            update={update}
           />
-          <PasswordForm />
+          <PasswordForm update={update} />
         </div>
       </div>
     </>

--- a/app/(routes)/mypage/types.ts
+++ b/app/(routes)/mypage/types.ts
@@ -1,3 +1,9 @@
+interface ProfileValuesType {
+  email: string;
+  nickname: string;
+  profileImageUrl: string | null;
+}
+
 interface ValidationType {
   isValid: boolean;
   message: string;
@@ -18,8 +24,10 @@ interface ProfileFormProps {
   email: string;
   nickname: string;
   profileImageUrl: string | null;
+  update: () => void;
 }
 export type {
+  ProfileValuesType,
   ProfileValidationsType,
   PasswordValidationsType,
   ProfileFormProps,

--- a/app/context/AuthContext.tsx
+++ b/app/context/AuthContext.tsx
@@ -5,13 +5,10 @@ import { LoginUserParams } from '@/_types/auth.type';
 import { UserType } from '@/_types/users.type';
 import { loginUser } from '@/api/auth.api';
 import { getUser } from '@/api/users.api';
+import { useRouter } from 'next/navigation';
 import { createContext, useCallback, useContext, useEffect } from 'react';
 
-/**
- * @todo 회원정보 수정 만들어야함
- */
-
-const AuthContext = createContext<{
+interface AuthContextType {
   user: UserType | null;
   loadingLogin: boolean;
   loadingUpdate: boolean;
@@ -20,7 +17,9 @@ const AuthContext = createContext<{
   loginErrorMessage: string | null;
   updateErrorMessage: string | null;
   update: () => void;
-}>({
+}
+
+const AuthContext = createContext<AuthContextType | undefined>({
   user: null,
   loadingLogin: false,
   loadingUpdate: false,
@@ -89,19 +88,20 @@ function AuthProvider({ children }: { children: React.ReactNode }) {
   );
 }
 
-function useAuth() {
+function useAuth(required = true) {
   const context = useContext(AuthContext);
-  // const router = useRouter();
+  const router = useRouter();
 
   if (!context) {
     throw new Error('must useAuth in AuthProvider');
   }
 
-  // useEffect(() => {
-  //   if (required && !context.user && !context.loadingUpdate) {
-  //     router.push('/login');
-  //   }
-  // }, [required, context.user, context.loadingUpdate, router]);
+  useEffect(() => {
+    console.log(location.href, context.user, context.loadingUpdate);
+    if (required && !context.user && !context.loadingUpdate) {
+      router.push('/login');
+    }
+  }, [required, context, router]);
 
   return context;
 }


### PR DESCRIPTION
## #️⃣ 연관된 이슈

- #127 

## 🔨작업 내용

### `update()`

`useAuth`가 이제 `update` 함수를 제공합니다.

`update` 는 사용하는 즉시 `useAuth`의 `user` 정보는 최신 데이터로 갱신합니다.

사용법

```ts
// 함수 추출
const { update } = useAuth();

// 호출
update()
```

### 유저 정보 갱신 로직 구현

update함수를 사용해 유저 정보는 변경하는 즉시 갱신된 정보를 불러오는 로직을 구현했습니다.

플로우는 다음과 같습니다.
1. 유저 정보 변경
2. `update` 호출
3. `user` 갱신
4. `user` 갱신으로 인한 페이지 리렌더링

### 권한이 없을 경우 리렌더링 되는 기능 구현

`useAuth` 호출 시, `required` 파라미터로 `true`를 전달 할 경우 로그인 하지 않은 유저를 `/login`으로 리다이렉트합니다.

사용법

```ts
const { ... } = useAuth(true);
```

### Auth Context 리팩토링

기존 Auth Context는 리렌더링 최적화가 되어 있지 않았습니다. 

해당 context를 최적화하는 동시에 코드 리팩토링을 진행했습니다.

기존에는 페이지 접속 시 총 7번의 리렌더링을 발생했지만 리팩토링을 진행 한 후 3번의 리팩토링만 발생합니다.

리팩토링이 3번 발생하더라도 실제 서버에 요청은 최초의 1번만 하기에 초기 페이지 렌더링 시간에 큰 영향을 미치진 않습니다.

## 💬 리뷰 요구사항

리렌더링을 줄이는데 너무 많은 시간을 소요한 거 같습니다.

추가적인 최적화를 위해서는 코드는 처음부터 다시 설계를 해야할 거 같아 현재 상태로 타협했습니다.

개선이 필요한 부분이 보인다면 언제든 말씀 부탁드립니다!
