### PR TITLE
[Feat] 대쉬보드 카드 드래그 api 구현

### DIFF
--- a/app/(routes)/dashboard/[dashboardId]/CreateCardButton.tsx
+++ b/app/(routes)/dashboard/[dashboardId]/CreateCardButton.tsx
@@ -7,8 +7,8 @@ export default function CreateCardButton() {
         <Image
           src="/images/icon/ic-plusbtn-purple.svg"
           alt="카드 생성 버튼"
-          layout="fill"
-          objectFit="contain"
+          fill
+          style={{ objectFit: 'contain' }}
         />
       </div>
     </div>

--- a/app/(routes)/dashboard/[dashboardId]/CreateColumnButton.tsx
+++ b/app/(routes)/dashboard/[dashboardId]/CreateColumnButton.tsx
@@ -11,8 +11,8 @@ export default function CreateColumnButton() {
           <Image
             src="/images/icon/ic-plusbtn-purple.svg"
             alt="카드 생성 버튼"
-            layout="fill"
-            objectFit="contain"
+            fill
+            style={{ objectFit: 'contain' }}
           />
         </div>
       </div>

--- a/app/(routes)/dashboard/[dashboardId]/Dashboard.tsx
+++ b/app/(routes)/dashboard/[dashboardId]/Dashboard.tsx
@@ -30,8 +30,6 @@ export type ItemGroupsType = {
 export default function DashBoard({ dashBoard }: { dashBoard: DashboardType }) {
   const [itemGroups, setItemGroups] = useState<ItemGroupsType>({});
   const [activeId, setActiveId] = useState<UniqueIdentifier | null>(null);
-  const [activeContainerId, setActiveContainerId] =
-    useState<UniqueIdentifier | null>(null);
 
   const sensors = useSensors(
     useSensor(MouseSensor),
@@ -83,12 +81,10 @@ export default function DashBoard({ dashBoard }: { dashBoard: DashboardType }) {
 
   const handleDragStart = ({ active }: DragStartEvent) => {
     setActiveId(active.id);
-    setActiveContainerId(active.data.current?.sortable.containerId);
   };
 
   const handleDragCancel = () => {
     setActiveId(null);
-    setActiveContainerId(null);
   };
 
   const throttledHandleDragOver = useMemo(
@@ -127,7 +123,7 @@ export default function DashBoard({ dashBoard }: { dashBoard: DashboardType }) {
               item: active.id,
             });
 
-            console.log('after move itemGroups: ', itemGroups);
+            // console.log('after move itemGroups: ', itemGroups);
             return data;
           });
         },
@@ -163,12 +159,6 @@ export default function DashBoard({ dashBoard }: { dashBoard: DashboardType }) {
       activeIndex == null ||
       overIndex == null
     ) {
-      return;
-    }
-
-    if (activeContainerId === overContainer) {
-      setActiveId(null);
-      setActiveContainerId(null);
       return;
     }
 
@@ -219,6 +209,7 @@ export default function DashBoard({ dashBoard }: { dashBoard: DashboardType }) {
         tags: tags,
         imageUrl: imageUrl,
       });
+      console.log('updateCard');
     } catch {
       setItemGroups(prevItemGroups);
     }

--- a/app/(routes)/dashboard/[dashboardId]/Droppable.tsx
+++ b/app/(routes)/dashboard/[dashboardId]/Droppable.tsx
@@ -44,8 +44,8 @@ export default function Droppable({
               <Image
                 src="/images/icon/ic-setting.svg"
                 alt="컬럼 수정 버튼"
-                layout="fill"
-                objectFit="contain"
+                fill
+                style={{ objectFit: 'contain' }}
               />
             </div>
           </div>

--- a/app/(routes)/dashboard/[dashboardId]/page.tsx
+++ b/app/(routes)/dashboard/[dashboardId]/page.tsx
@@ -26,7 +26,6 @@ export default function DashBoardPage() {
     const fetchDashBoard = async () => {
       const numericDashboardId = Number(dashboardId);
       try {
-        console.log(dashboardId);
         const data = await getDashboard({ dashboardId: numericDashboardId });
 
         setDashBoard(data);

--- a/app/_types/cards.type.ts
+++ b/app/_types/cards.type.ts
@@ -8,7 +8,7 @@ interface CardType {
     profileImageUrl: string | null;
     nickname: string;
     id: number;
-  } | null;
+  };
   imageUrl: string | null;
   teamId: string;
   columnId: number;


### PR DESCRIPTION
## #️⃣ 연관된 이슈

- #140 

## 🔨작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

- [x] 카드를 다른 컬럼으로 옮겼을 때의 데이터를 서버에 업데이트 요청
- [x] 클라이언트에선 카드를 자유롭게 배치할 수 있으나, 페이지가 언마운트되면 다시 서버로부터 받은 초기 상태의 데이터가 랜더링 됨.

## 💬 리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요

- 컬럼/카드/수정 모달 부분들은 추후 수정할 생각입니다.
- 모바일과 태블릿 버전에서도 잘 작동하는 것 같습니다.
- 혹시 테스트 해 보고 싶으신 분은 카드가 만들어져있는 아래 계정 사용해주시면 됩니다.
- 테스트 계정
email: qwer@qwer.com
password: 1q2w3e4r
dashboard: 테스트1

