### PR TITLE
[Bug] 로그인/회원가입 페이지 접속 시, 리다이렉트 전 레이아웃이 렌더링 되던 문제 해결

### DIFF
--- a/app/(routes)/login/page.tsx
+++ b/app/(routes)/login/page.tsx
@@ -8,29 +8,21 @@ import { ValuesType } from './loginType';
 import { DEFAULT_VALIDATIONS, validateSchema } from './validate';
 import { useAuth } from '@/context/AuthContext';
 import Modal from '@/_components/Auth/Modal';
-import { useRouter } from 'next/navigation';
+import { useRouter, useSearchParams } from 'next/navigation';
 
 const DEFAULT_VALUES: ValuesType = {
   email: '',
   password: '',
 };
 
-/**
- * @todo
- * loadingUser 사용해서 JWT 변조 에러처리
- */
 export default function LoginPage() {
   const [values, setValues] = useState(DEFAULT_VALUES);
   const [validations, setValidations] = useState(DEFAULT_VALIDATIONS);
   const [isFormValid, setIsFormValid] = useState(false);
   const [showModal, setShowModal] = useState(false);
-  const {
-    user,
-    login,
-    loading,
-    errorMessage,
-  } = useAuth();
+  const { user, login, loading, errorMessage } = useAuth();
   const router = useRouter();
+  const goto = useSearchParams().get('goto') || 'mydashboard';
 
   const handleCloseModal = () => setShowModal(false);
 
@@ -71,12 +63,10 @@ export default function LoginPage() {
     validateForm();
   }, [validateForm]);
 
-  useEffect(() => {
-    if (user) {
-      setValues(DEFAULT_VALUES);
-      router.push('/mydashboard');
-    }
-  }, [user, router]);
+  if (user) {
+    router.push(goto);
+    return null;
+  }
 
   return (
     <>

--- a/app/(routes)/login/page.tsx
+++ b/app/(routes)/login/page.tsx
@@ -8,7 +8,7 @@ import { ValuesType } from './loginType';
 import { DEFAULT_VALIDATIONS, validateSchema } from './validate';
 import { useAuth } from '@/context/AuthContext';
 import Modal from '@/_components/Auth/Modal';
-import { useRouter, useSearchParams } from 'next/navigation';
+import Navigate from '@/_components/Auth/Navigate';
 const DEFAULT_VALUES: ValuesType = {
   email: '',
   password: '',
@@ -60,8 +60,12 @@ export default function LoginPage() {
     validateForm();
   }, [validateForm]);
 
+  if (loading.auth) {
+    return null;
+  }
+
   return (
-    <Suspense fallback={<div>loading</div>}>
+    <Suspense fallback={null}>
       {user ? (
         <Navigate />
       ) : (
@@ -104,17 +108,4 @@ export default function LoginPage() {
       )}
     </Suspense>
   );
-}
-
-function Navigate() {
-  const router = useRouter();
-  const searchParams = useSearchParams();
-  const goto = searchParams.get('goto') || 'mydashboard';
-
-  useEffect(() => {
-    if (typeof window !== undefined && searchParams) {
-      router.push(goto);
-    }
-  });
-  return null;
 }

--- a/app/(routes)/login/page.tsx
+++ b/app/(routes)/login/page.tsx
@@ -3,13 +3,12 @@
 import AuthFooter from '@/_components/Auth/AuthFooter';
 import AuthHeader from '@/_components/Auth/AuthHeader';
 import InputField from '@/_components/Auth/InputField';
-import { useCallback, useEffect, useState } from 'react';
+import { Suspense, useCallback, useEffect, useState } from 'react';
 import { ValuesType } from './loginType';
 import { DEFAULT_VALIDATIONS, validateSchema } from './validate';
 import { useAuth } from '@/context/AuthContext';
 import Modal from '@/_components/Auth/Modal';
 import { useRouter, useSearchParams } from 'next/navigation';
-
 const DEFAULT_VALUES: ValuesType = {
   email: '',
   password: '',
@@ -21,8 +20,6 @@ export default function LoginPage() {
   const [isFormValid, setIsFormValid] = useState(false);
   const [showModal, setShowModal] = useState(false);
   const { user, login, loading, errorMessage } = useAuth();
-  const router = useRouter();
-  const goto = useSearchParams().get('goto') || 'mydashboard';
 
   const handleCloseModal = () => setShowModal(false);
 
@@ -63,44 +60,61 @@ export default function LoginPage() {
     validateForm();
   }, [validateForm]);
 
-  if (user) {
-    router.push(goto);
-    return null;
-  }
-
   return (
-    <>
-      {showModal && (
-        <Modal text={errorMessage.login as string} onClick={handleCloseModal} />
+    <Suspense fallback={<div>loading</div>}>
+      {user ? (
+        <Navigate />
+      ) : (
+        <>
+          {showModal && (
+            <Modal
+              text={errorMessage.login as string}
+              onClick={handleCloseModal}
+            />
+          )}
+          <div className="mx-auto w-full max-w-xs pb-8 pt-20 tablet:max-w-lg tablet:pt-52">
+            <AuthHeader text="오늘도 만나서 반가워요!" />
+            <form className="mb-6 flex flex-col gap-6" onSubmit={handleSubmit}>
+              <InputField
+                name="email"
+                value={values.email}
+                validation={validations.email}
+                onChange={handleChangeValue}
+                onBlur={handleBlurInput}
+              />
+              <InputField
+                name="password"
+                type="password"
+                value={values.password}
+                validation={validations.password}
+                onChange={handleChangeValue}
+                onBlur={handleBlurInput}
+              />
+              <button
+                className="w-full select-none rounded-lg border bg-violet-5534DA py-3.5 text-lg font-medium text-white disabled:bg-gray-9FA6B2"
+                type="submit"
+                disabled={!isFormValid || loading.login}
+              >
+                로그인
+              </button>
+            </form>
+            <AuthFooter to="signup" />
+          </div>
+        </>
       )}
-      <div className="mx-auto w-full max-w-xs pb-8 pt-20 tablet:max-w-lg tablet:pt-52">
-        <AuthHeader text="오늘도 만나서 반가워요!" />
-        <form className="mb-6 flex flex-col gap-6" onSubmit={handleSubmit}>
-          <InputField
-            name="email"
-            value={values.email}
-            validation={validations.email}
-            onChange={handleChangeValue}
-            onBlur={handleBlurInput}
-          />
-          <InputField
-            name="password"
-            type="password"
-            value={values.password}
-            validation={validations.password}
-            onChange={handleChangeValue}
-            onBlur={handleBlurInput}
-          />
-          <button
-            className="w-full select-none rounded-lg border bg-violet-5534DA py-3.5 text-lg font-medium text-white disabled:bg-gray-9FA6B2"
-            type="submit"
-            disabled={!isFormValid || loading.login}
-          >
-            로그인
-          </button>
-        </form>
-        <AuthFooter to="signup" />
-      </div>
-    </>
+    </Suspense>
   );
+}
+
+function Navigate() {
+  const router = useRouter();
+  const searchParams = useSearchParams();
+  const goto = searchParams.get('goto') || 'mydashboard';
+
+  useEffect(() => {
+    if (typeof window !== undefined && searchParams) {
+      router.push(goto);
+    }
+  });
+  return null;
 }

--- a/app/(routes)/mypage/page.tsx
+++ b/app/(routes)/mypage/page.tsx
@@ -9,7 +9,7 @@ import MyDashboardNavBar from '@/_components/Navbar/MyDashboardNavBar';
 import SideBar from '@/_components/Sidebar/SideBar';
 
 export default function MyPage() {
-  const { user, update } = useAuth();
+  const { user, update } = useAuth(true);
 
   return (
     <>

--- a/app/(routes)/signup/page.tsx
+++ b/app/(routes)/signup/page.tsx
@@ -1,17 +1,18 @@
 'use client';
 
-import { useCallback, useEffect, useState } from 'react';
+import { Suspense, useCallback, useEffect, useState } from 'react';
 import CheckboxField from './CheckboxField';
 import { DEFAULT_VALIDATIONS, validateSchema } from './validate';
 import { ValuesType } from './signupType';
 import { createUser } from '@/api/users.api';
 import useAsync from '@/_hooks/useAsync';
-import { useRouter, useSearchParams } from 'next/navigation';
+import { useRouter } from 'next/navigation';
 import InputField from '@/_components/Auth/InputField';
 import Modal from '@/_components/Auth/Modal';
 import AuthHeader from '@/_components/Auth/AuthHeader';
 import AuthFooter from '@/_components/Auth/AuthFooter';
 import { useAuth } from '@/context/AuthContext';
+import Navigate from '@/_components/Auth/Navigate';
 
 const DEFAULT_VALUES: ValuesType = {
   email: '',
@@ -29,13 +30,12 @@ export default function SignUp() {
   const {
     data: userData,
     excute: createUserAsync,
-    loading,
+    loading: loadingUser,
     error,
     errorMessage,
   } = useAsync(createUser);
-  const { user } = useAuth();
+  const { user, loading } = useAuth();
   const router = useRouter();
-  const goto = useSearchParams().get('goto') || 'mydashboard';
 
   const handleClickClose = () => setShowError(false);
   const handleClickSuccess = () => router.push('/login');
@@ -86,66 +86,71 @@ export default function SignUp() {
     validateForm();
   }, [validateForm]);
 
-  if (user) {
-    router.push(goto);
+  if (loading.auth) {
     return null;
   }
 
   return (
-    <>
-      {!!userData && (
-        <Modal text="가입이 완료되었습니다!" onClick={handleClickSuccess} />
+    <Suspense fallback={<div>loading</div>}>
+      {user ? (
+        <Navigate />
+      ) : (
+        <>
+          {!!userData && (
+            <Modal text="가입이 완료되었습니다!" onClick={handleClickSuccess} />
+          )}
+          {showError && (
+            <Modal text={errorMessage as string} onClick={handleClickClose} />
+          )}
+          <div className="mx-auto w-full max-w-xs pb-8 pt-16 target:mt-40 tablet:max-w-lg">
+            <AuthHeader text="첫 방문을 환영합니다!!" />
+            <form className="mb-6 flex flex-col gap-6" onSubmit={handleSubmit}>
+              <InputField
+                name="email"
+                value={values.email}
+                validation={validations.email}
+                onChange={handleChangeValue}
+                onBlur={handleBlurInput}
+              />
+              <InputField
+                name="nickname"
+                value={values.nickname}
+                validation={validations.nickname}
+                onChange={handleChangeValue}
+                onBlur={handleBlurInput}
+              />
+              <InputField
+                name="password"
+                type="password"
+                value={values.password}
+                validation={validations.password}
+                onChange={handleChangeValue}
+                onBlur={handleBlurInput}
+              />
+              <InputField
+                name="repeat"
+                type="password"
+                value={values.repeat}
+                validation={validations.repeat}
+                onChange={handleChangeValue}
+                onBlur={handleBlurInput}
+              />
+              <CheckboxField
+                isChecked={isChecked}
+                onChange={handleChangeCheckbox}
+              />
+              <button
+                className="w-full select-none rounded-lg border bg-violet-5534DA py-3.5 text-lg font-medium text-white disabled:bg-gray-9FA6B2"
+                type="submit"
+                disabled={!isFormValid || loadingUser}
+              >
+                가입하기
+              </button>
+            </form>
+            <AuthFooter to="signin" />
+          </div>
+        </>
       )}
-      {showError && (
-        <Modal text={errorMessage as string} onClick={handleClickClose} />
-      )}
-      <div className="mx-auto w-full max-w-xs pb-8 pt-16 target:mt-40 tablet:max-w-lg">
-        <AuthHeader text="첫 방문을 환영합니다!!" />
-        <form className="mb-6 flex flex-col gap-6" onSubmit={handleSubmit}>
-          <InputField
-            name="email"
-            value={values.email}
-            validation={validations.email}
-            onChange={handleChangeValue}
-            onBlur={handleBlurInput}
-          />
-          <InputField
-            name="nickname"
-            value={values.nickname}
-            validation={validations.nickname}
-            onChange={handleChangeValue}
-            onBlur={handleBlurInput}
-          />
-          <InputField
-            name="password"
-            type="password"
-            value={values.password}
-            validation={validations.password}
-            onChange={handleChangeValue}
-            onBlur={handleBlurInput}
-          />
-          <InputField
-            name="repeat"
-            type="password"
-            value={values.repeat}
-            validation={validations.repeat}
-            onChange={handleChangeValue}
-            onBlur={handleBlurInput}
-          />
-          <CheckboxField
-            isChecked={isChecked}
-            onChange={handleChangeCheckbox}
-          />
-          <button
-            className="w-full select-none rounded-lg border bg-violet-5534DA py-3.5 text-lg font-medium text-white disabled:bg-gray-9FA6B2"
-            type="submit"
-            disabled={!isFormValid || loading}
-          >
-            가입하기
-          </button>
-        </form>
-        <AuthFooter to="signin" />
-      </div>
-    </>
+    </Suspense>
   );
 }

--- a/app/(routes)/signup/page.tsx
+++ b/app/(routes)/signup/page.tsx
@@ -6,11 +6,12 @@ import { DEFAULT_VALIDATIONS, validateSchema } from './validate';
 import { ValuesType } from './signupType';
 import { createUser } from '@/api/users.api';
 import useAsync from '@/_hooks/useAsync';
-import { useRouter } from 'next/navigation';
+import { useRouter, useSearchParams } from 'next/navigation';
 import InputField from '@/_components/Auth/InputField';
 import Modal from '@/_components/Auth/Modal';
 import AuthHeader from '@/_components/Auth/AuthHeader';
 import AuthFooter from '@/_components/Auth/AuthFooter';
+import { useAuth } from '@/context/AuthContext';
 
 const DEFAULT_VALUES: ValuesType = {
   email: '',
@@ -32,7 +33,9 @@ export default function SignUp() {
     error,
     errorMessage,
   } = useAsync(createUser);
+  const { user } = useAuth();
   const router = useRouter();
+  const goto = useSearchParams().get('goto') || 'mydashboard';
 
   const handleClickClose = () => setShowError(false);
   const handleClickSuccess = () => router.push('/login');
@@ -82,6 +85,11 @@ export default function SignUp() {
   useEffect(() => {
     validateForm();
   }, [validateForm]);
+
+  if (user) {
+    router.push(goto);
+    return null;
+  }
 
   return (
     <>

--- a/app/_components/Auth/Navigate.tsx
+++ b/app/_components/Auth/Navigate.tsx
@@ -1,0 +1,15 @@
+import { useRouter, useSearchParams } from 'next/navigation';
+import { useEffect } from 'react';
+
+export default function Navigate() {
+  const router = useRouter();
+  const goto = useSearchParams().get('goto') || 'mydashboard';
+
+  useEffect(() => {
+    if (typeof window !== undefined && goto && router) {
+      router.push(goto);
+    }
+  }, [goto, router]);
+
+  return null;
+}

--- a/app/context/AuthContext.tsx
+++ b/app/context/AuthContext.tsx
@@ -6,19 +6,25 @@ import { UserType } from '@/_types/users.type';
 import { loginUser } from '@/api/auth.api';
 import { getUser } from '@/api/users.api';
 import { useRouter } from 'next/navigation';
-import { createContext, useCallback, useContext, useEffect, useState } from 'react';
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useState,
+} from 'react';
 
 interface AuthContextType {
   user: UserType | null;
-  loading : {
-    auth : boolean;
-    login : boolean;
-    update : boolean;
-  }
-  errorMessage : {
-    login : string | null;
-    update : string | null;
-  }
+  loading: {
+    auth: boolean;
+    login: boolean;
+    update: boolean;
+  };
+  errorMessage: {
+    login: string | null;
+    update: string | null;
+  };
   login: ({ email, password }: LoginUserParams) => void;
   logout: () => void;
   update: () => void;
@@ -26,24 +32,8 @@ interface AuthContextType {
 
 const AuthContext = createContext<AuthContextType | undefined>(undefined);
 
-// {
-//   user: null,
-//   loading : {
-//     auth : true,
-//     login : false,
-//     update : false,
-//   },
-//   errorMessage: {
-//     login : null,
-//     update : null,
-//   },
-//   login: () => {},
-//   logout: () => {},
-//   update: () => {},
-// }
-
 function AuthProvider({ children }: { children: React.ReactNode }) {
-  const [accessToken, setAccessToken] = useState<string | null>(null)
+  const [accessToken, setAccessToken] = useState<string | null>(null);
   const [loadingAuth, setLoadingAuth] = useState(true);
   const key = process.env.NEXT_PUBLIC_ACCESS_TOKEN_KEY || null;
   const {
@@ -60,36 +50,39 @@ function AuthProvider({ children }: { children: React.ReactNode }) {
     errorMessage: loginErrorMessage,
   } = useAsync(loginUser);
 
-  const login = useCallback(async ({ email, password }: LoginUserParams) => {
-    await _loginUser({ email, password });
-  }, [_loginUser])
+  const login = useCallback(
+    async ({ email, password }: LoginUserParams) => {
+      await _loginUser({ email, password });
+    },
+    [_loginUser],
+  );
 
   const logout = useCallback(() => {
     if (!key) return;
     localStorage.removeItem(key);
     setAccessToken(null);
     clearUser();
-  },[key, clearUser]);
+  }, [key, clearUser]);
 
   const update = useCallback(() => {
     _getUser(undefined);
   }, [_getUser]);
 
-  useEffect(()=>{
-    if(!key) {
+  useEffect(() => {
+    if (!key) {
       setAccessToken(null);
       throw new Error(`Can't load Key`);
     }
     setAccessToken(localStorage.getItem(key) || null);
-  }, [key])
+  }, [key]);
 
-  useEffect(()=>{
+  useEffect(() => {
     if (key && loginData) {
       const next = loginData.accessToken || null;
-      setAccessToken(next)
+      setAccessToken(next);
       localStorage.setItem(key, next);
     }
-  }, [key, loginData])
+  }, [key, loginData]);
 
   useEffect(() => {
     if (accessToken) {
@@ -97,24 +90,24 @@ function AuthProvider({ children }: { children: React.ReactNode }) {
     }
   }, [_getUser, accessToken]);
 
-  useEffect(()=>{
-    if(userData || updateErrorMessage){
+  useEffect(() => {
+    if (userData || updateErrorMessage) {
       setLoadingAuth(false);
     }
-  },[userData, updateErrorMessage])
+  }, [userData, updateErrorMessage]);
 
   return (
     <AuthContext.Provider
       value={{
         user: userData,
-        loading : {
-          auth : loadingAuth,
-          login : loadingLogin,
-          update : loadingUpdate,
+        loading: {
+          auth: loadingAuth,
+          login: loadingLogin,
+          update: loadingUpdate,
         },
-        errorMessage : {
-          login : loginErrorMessage,
-          update : updateErrorMessage
+        errorMessage: {
+          login: loginErrorMessage,
+          update: updateErrorMessage,
         },
         login,
         logout,
@@ -126,7 +119,7 @@ function AuthProvider({ children }: { children: React.ReactNode }) {
   );
 }
 
-function useAuth(required : boolean = false) {
+function useAuth(required: boolean = false) {
   const context = useContext(AuthContext);
   const router = useRouter();
 
@@ -135,10 +128,21 @@ function useAuth(required : boolean = false) {
   }
 
   useEffect(() => {
-    if (required && !context.user && !context.loading.auth && !context.loading.login) {
-      router.push('/login');
+    if (
+      required &&
+      !context.user &&
+      !context.loading.auth &&
+      !context.loading.login
+    ) {
+      router.push(`/login?goto=${location.pathname}`);
     }
-  }, [required, context.user, context.loading.auth, context.loading.login,router]);
+  }, [
+    required,
+    context.user,
+    context.loading.auth,
+    context.loading.login,
+    router,
+  ]);
 
   return context;
 }


### PR DESCRIPTION
## #️⃣ 연관된 이슈

- #147 

## 🔨작업 내용

### 1. 리다이렉트 전 레이아웃이 렌더링 되던 문제 해결

기존 코드에서는 `useEffect`를 활용해 렌더링 된 후 로그인 여부를 판단했습니다.

`useEffect`는 페이지가 렌더링 된 후 동작합니다. 즉, 리다이렉트 전에 무조건 페이지 레이아웃이 보일 수 밖에 없습니다.

```ts
useEffect(() => {
    if (user) {
      router.push('/mydashboard');
    }
  }, [user, router]);
```

개선된 코드에서는 `if`문을 활용해 로그인 여부를 판단했습니다.

추가적으로 로그인 시 `null`을 반환해 혹시 모를 레이아웃 렌더링을 방지했습니다.

```ts
const goto = "도착 경로"

if (user) {
    router.push(goto);
    return null;
  }
```

### 2. 리다이렉트 도착 경로를 정하는 로직 변경

기존의 코드에서 인증이 필요한 페이지에 비인증 접속 시 `/login`으로 리다이텍트합니다. 

이후 로그인 하면 `/mydashboard`로 리다이렉트합니다.

```ts
// useAuth.tsx
router.push('/login');
```

```ts
// login/page.tsx
useEffect(() => {
    if (user) {
      router.push('/mydashboard');
    }
  }, [user, router]);
```

개선된 코드에서는 인증이 필요한 페이지에 비인증 접속 시 `/login?goto="접속페이지"`로 리다이텍트합니다. 

예시로 로그인을 하지 않고 `/mypage`로 접속을 한다고 할 때 `/login?goto=/mypage`로 리다이렉트합니다.

이후 로그인을 하면 `goto` 쿼리에 들어 있던 경로로 리다이렉트합니다.

만약 `goto` 쿼리에 들어있는 경로가 없다면 기존과 동일하게 `/mydashboard`로 리다이렉트합니다.

```ts
// useAuth.tsx
router.push(`/login?goto=${location.pathname}`);
```

```ts
// login/page.tsx
  if (user) {
    router.push(goto);
    return null;
  }
```

### 3. 계정 관리 페이지 인가 접속만 허용

기존 useAuth의 결함으로 인해 인가 없이도 접속이 가능했습니다.

해당 문제를 해결했습니다.
