### PR TITLE
[Fix] QA 개선 사항 반영

### DIFF
--- a/app/(routes)/mypage/PasswordForm.tsx
+++ b/app/(routes)/mypage/PasswordForm.tsx
@@ -7,6 +7,7 @@ import {
 } from './validate';
 import useAsync from '@/_hooks/useAsync';
 import { updatePassword } from '@/api/auth.api';
+import Modal from '@/_components/Auth/Modal';
 
 const DEFAUTL_VALUES = {
   current: '',
@@ -18,8 +19,20 @@ export default function PasswordForm({ update }: { update: () => void }) {
   const [values, setValues] = useState(DEFAUTL_VALUES);
   const [validations, setValidations] = useState(DEFAULT_PASSWORD_VALIDATIONS);
   const [isFormValid, setIsFormValid] = useState(false);
-  const { data: updateData, excute: _updatePassword } =
-    useAsync(updatePassword);
+  const {
+    data: updateData,
+    excute: _updatePassword,
+    errorMessage: updateErrorMessage,
+    clear,
+  } = useAsync(updatePassword);
+  const [showError, setShowError] = useState(false);
+  const [showSuccess, setShowSuccess] = useState(false);
+
+  const handleClickCloseError = () => setShowError(false);
+  const handleClickCloseSuccess = () => {
+    clear();
+    setShowSuccess(false);
+  };
 
   const handleChangeValue = (event: ChangeEvent<HTMLInputElement>) => {
     const { name, value } = event.target;
@@ -69,53 +82,80 @@ export default function PasswordForm({ update }: { update: () => void }) {
   }, [validations]);
 
   useEffect(() => {
+    setValues(DEFAUTL_VALUES);
     update();
   }, [updateData, update]);
 
+  useEffect(() => {
+    if (updateErrorMessage) {
+      setShowError(true);
+    }
+  }, [updateErrorMessage]);
+
+  useEffect(() => {
+    if (updateData) {
+      setShowSuccess(true);
+    }
+  }, [updateData]);
+
   return (
-    <form
-      className="min-w-[18rem] rounded-lg bg-white p-4 tablet:w-[42rem] tablet:rounded-2xl tablet:p-6"
-      onSubmit={handleSubmit}
-    >
-      <h2 className="mb-10 text-2lg font-bold text-black-333236 tablet:mb-6 tablet:text-2xl">
-        비밀번호 변경
-      </h2>
-      <div className="flex flex-col gap-4">
-        <InputField
-          name="current"
-          value={values.current}
-          onChange={handleChangeValue}
-          validation={validations.current}
-          label="현재 비밀번호"
-          placeholder="비밀번호 입력"
-          onBlur={handleBlurInput}
+    <>
+      {showSuccess && (
+        <Modal
+          text="비밀번호 변경에 성공했습니다."
+          onClick={handleClickCloseSuccess}
         />
-        <InputField
-          name="changed"
-          value={values.changed}
-          onChange={handleChangeValue}
-          validation={validations.changed}
-          label="새 비밀번호"
-          placeholder="새 비밀번호 입력"
-          onBlur={handleBlurInput}
+      )}
+      {showError && (
+        <Modal
+          text={updateErrorMessage as string}
+          onClick={handleClickCloseError}
         />
-        <InputField
-          name="confirmed"
-          value={values.confirmed}
-          onChange={handleChangeValue}
-          validation={validations.confirmed}
-          label="새 비밀번호 확인"
-          placeholder="새 비밀번호 확인 입력"
-          onBlur={handleBlurInput}
-        />
-        <button
-          className="w-full select-none rounded-lg border bg-violet-5534DA py-3.5 text-lg font-medium text-white disabled:bg-gray-9FA6B2"
-          type="submit"
-          disabled={!isFormValid}
-        >
-          변경
-        </button>
-      </div>
-    </form>
+      )}
+      <form
+        className="min-w-[18rem] rounded-lg bg-white p-4 tablet:w-[42rem] tablet:rounded-2xl tablet:p-6"
+        onSubmit={handleSubmit}
+      >
+        <h2 className="mb-10 text-2lg font-bold text-black-333236 tablet:mb-6 tablet:text-2xl">
+          비밀번호 변경
+        </h2>
+        <div className="flex flex-col gap-4">
+          <InputField
+            name="current"
+            value={values.current}
+            onChange={handleChangeValue}
+            validation={validations.current}
+            label="현재 비밀번호"
+            placeholder="비밀번호 입력"
+            onBlur={handleBlurInput}
+          />
+          <InputField
+            name="changed"
+            value={values.changed}
+            onChange={handleChangeValue}
+            validation={validations.changed}
+            label="새 비밀번호"
+            placeholder="새 비밀번호 입력"
+            onBlur={handleBlurInput}
+          />
+          <InputField
+            name="confirmed"
+            value={values.confirmed}
+            onChange={handleChangeValue}
+            validation={validations.confirmed}
+            label="새 비밀번호 확인"
+            placeholder="새 비밀번호 확인 입력"
+            onBlur={handleBlurInput}
+          />
+          <button
+            className="w-full select-none rounded-lg border bg-violet-5534DA py-3.5 text-lg font-medium text-white disabled:bg-gray-9FA6B2"
+            type="submit"
+            disabled={!isFormValid}
+          >
+            변경
+          </button>
+        </div>
+      </form>
+    </>
   );
 }

--- a/app/(routes)/mypage/PasswordForm.tsx
+++ b/app/(routes)/mypage/PasswordForm.tsx
@@ -70,7 +70,10 @@ export default function PasswordForm({ update }: { update: () => void }) {
   const handleSubmit = (event: FormEvent<HTMLFormElement>) => {
     event.preventDefault();
     if (!isFormValid) return;
-    _updatePassword({ password: values.current, newPassword: values.changed });
+    _updatePassword({
+      password: values.current.trim(),
+      newPassword: values.changed.trim(),
+    });
   };
 
   useEffect(() => {

--- a/app/(routes)/mypage/ProfileForm.tsx
+++ b/app/(routes)/mypage/ProfileForm.tsx
@@ -5,6 +5,7 @@ import useAsync from '@/_hooks/useAsync';
 import { createProfileImage, updateUser } from '@/api/users.api';
 import { ProfileFormProps, ProfileValuesType } from './types';
 import { DEFAULT_PROFILE_VALIDATIONS, validate } from './validate';
+import Modal from '@/_components/Auth/Modal';
 
 const DEFAULT_VALUES: ProfileValuesType = {
   email: '',
@@ -24,9 +25,21 @@ export default function ProfileForm({
   const {
     data: profileData,
     excute: _createProfileImage,
+    errorMessage: imageErrorMessage,
     clear: claerProfileImage,
   } = useAsync(createProfileImage);
-  const { data: updateData, excute: _updateUser } = useAsync(updateUser);
+  const {
+    data: updateData,
+    excute: _updateUser,
+    errorMessage: updateErrorMessage,
+  } = useAsync(updateUser);
+  const [showUpdateError, setShowUpdateError] = useState(false);
+  const [showImageError, setShowImageError] = useState(false);
+  const [showSuccess, setShowSuccess] = useState(false);
+
+  const handleClickCloseUpdateError = () => setShowUpdateError(false);
+  const handleClickCloseImageError = () => setShowImageError(false);
+  const handleClickCloseSuccess = () => setShowSuccess(false);
 
   /**
    * 프로필 폼 입력 필드 값 변경 핸들러
@@ -125,46 +138,84 @@ export default function ProfileForm({
     setValues({ email, nickname, profileImageUrl });
   }, [email, nickname, profileImageUrl]);
 
+  useEffect(() => {
+    if (updateErrorMessage) {
+      setShowUpdateError(true);
+    }
+  }, [updateErrorMessage]);
+
+  useEffect(() => {
+    if (imageErrorMessage) {
+      setShowUpdateError(true);
+    }
+  }, [imageErrorMessage]);
+
+  useEffect(() => {
+    if (updateData) {
+      setShowSuccess(true);
+    }
+  }, [updateData]);
+
   return (
-    <form
-      className="min-w-[18rem] rounded-lg bg-white p-4 tablet:w-[42rem] tablet:rounded-2xl tablet:p-6"
-      onSubmit={handleSubmit}
-    >
-      <h2 className="mb-10 text-2lg font-bold text-black-333236 tablet:mb-6 tablet:text-2xl">
-        프로필
-      </h2>
-      <div className="tablet:flex">
-        <ImageInputField
-          profileImageUrl={values.profileImageUrl}
-          onChange={handleChangeProfile}
+    <>
+      {showSuccess && (
+        <Modal
+          text="프로필 변경에 성공했습니다."
+          onClick={handleClickCloseSuccess}
         />
-        <div className="mt-10 flex flex-col gap-4 tablet:ml-10 tablet:mt-0 tablet:grow">
-          <InputField
-            name="email"
-            type="text"
-            placeholder={email}
-            value={''}
-            validation={{ isValid: false, message: '' }}
-            readonly={true}
-            onChange={handleChangeValue}
+      )}
+      {showUpdateError && (
+        <Modal
+          text={updateErrorMessage as string}
+          onClick={handleClickCloseUpdateError}
+        />
+      )}
+      {showImageError && (
+        <Modal
+          text={imageErrorMessage as string}
+          onClick={handleClickCloseImageError}
+        />
+      )}
+      <form
+        className="min-w-[18rem] rounded-lg bg-white p-4 tablet:w-[42rem] tablet:rounded-2xl tablet:p-6"
+        onSubmit={handleSubmit}
+      >
+        <h2 className="mb-10 text-2lg font-bold text-black-333236 tablet:mb-6 tablet:text-2xl">
+          프로필
+        </h2>
+        <div className="tablet:flex">
+          <ImageInputField
+            profileImageUrl={values.profileImageUrl}
+            onChange={handleChangeProfile}
           />
-          <InputField
-            name="nickname"
-            type="text"
-            placeholder={nickname}
-            value={values.nickname}
-            validation={validations.nickname}
-            onChange={handleChangeValue}
-          />
-          <button
-            className="w-full select-none rounded-lg border bg-violet-5534DA py-3.5 text-lg font-medium text-white disabled:bg-gray-9FA6B2"
-            type="submit"
-            disabled={!isFormValid}
-          >
-            저장
-          </button>
+          <div className="mt-10 flex flex-col gap-4 tablet:ml-10 tablet:mt-0 tablet:grow">
+            <InputField
+              name="email"
+              type="text"
+              placeholder={email}
+              value={''}
+              validation={{ isValid: false, message: '' }}
+              readonly={true}
+              onChange={handleChangeValue}
+            />
+            <InputField
+              name="nickname"
+              type="text"
+              placeholder={nickname}
+              value={values.nickname}
+              validation={validations.nickname}
+              onChange={handleChangeValue}
+            />
+            <button
+              className="w-full select-none rounded-lg border bg-violet-5534DA py-3.5 text-lg font-medium text-white disabled:bg-gray-9FA6B2"
+              type="submit"
+              disabled={!isFormValid}
+            >
+              저장
+            </button>
+          </div>
         </div>
-      </div>
-    </form>
+      </form>
+    </>
   );
 }

--- a/app/(routes)/mypage/page.tsx
+++ b/app/(routes)/mypage/page.tsx
@@ -7,6 +7,7 @@ import PasswordForm from './PasswordForm';
 import Image from 'next/image';
 import MyDashboardNavBar from '@/_components/Navbar/MyDashboardNavBar';
 import SideBar from '@/_components/Sidebar/SideBar';
+import Container from '@/_components/layout/Container';
 
 export default function MyPage() {
   const { user, update } = useAuth(true);
@@ -15,26 +16,24 @@ export default function MyPage() {
     <>
       <SideBar />
       <MyDashboardNavBar />
-      <div className="ml-16 mt-[4.5rem] bg-gray-F5F5F5 tablet:ml-40 pc:ml-72">
-        <div className="flex flex-col gap-6 p-6">
-          <Link
-            href="/mydashboard"
-            className="flex w-fit items-center justify-center gap-2"
-          >
-            <div className="relative h-4 w-4 tablet:h-6 tablet:w-6">
-              <Image fill src="/images/icon/icon_arrow.svg" alt="돌아가기" />
-            </div>
-            <span className="text-sm tablet:text-lg">돌아가기</span>
-          </Link>
-          <ProfileForm
-            email={user?.email as string}
-            nickname={user?.nickname as string}
-            profileImageUrl={user?.profileImageUrl as string | null}
-            update={update}
-          />
-          <PasswordForm update={update} />
-        </div>
-      </div>
+      <Container className="flex flex-col gap-6 p-6">
+        <Link
+          href="/mydashboard"
+          className="flex w-fit items-center justify-center gap-2"
+        >
+          <div className="relative h-4 w-4 tablet:h-6 tablet:w-6">
+            <Image fill src="/images/icon/icon_arrow.svg" alt="돌아가기" />
+          </div>
+          <span className="text-sm tablet:text-lg">돌아가기</span>
+        </Link>
+        <ProfileForm
+          email={user?.email as string}
+          nickname={user?.nickname as string}
+          profileImageUrl={user?.profileImageUrl as string | null}
+          update={update}
+        />
+        <PasswordForm update={update} />
+      </Container>
     </>
   );
 }

--- a/app/_components/Auth/Modal.tsx
+++ b/app/_components/Auth/Modal.tsx
@@ -6,7 +6,7 @@ export default function Modal({
   onClick: () => void;
 }) {
   return (
-    <div className="fixed z-20 flex h-full w-full items-center justify-center bg-black-171717/80">
+    <div className="fixed left-0 top-0 z-20 flex h-dvh w-dvw items-center justify-center bg-black-171717/80">
       <div className="flex h-48 min-w-80 flex-col items-center justify-center gap-8 rounded-2xl bg-white px-16 py-10">
         <div className="text-xl font-medium text-black-333236">{text}</div>
         <button

--- a/app/_components/layout/Container.tsx
+++ b/app/_components/layout/Container.tsx
@@ -5,7 +5,7 @@ interface ContainerProps {
 
 export default function Container({ children, className }: ContainerProps) {
   return (
-    <div className="bg-gray-F5F5F5 pl-16 pt-[3.75rem] tablet:pl-40 tablet:pt-[4.375rem] pc:pl-72">
+    <div className="min-h-[100vh] min-w-[100vw] bg-gray-F5F5F5 pl-16 pt-[3.75rem] tablet:pl-40 tablet:pt-[4.375rem] pc:pl-72">
       <div className={className}>{children}</div>
     </div>
   );

--- a/app/context/AuthContext.tsx
+++ b/app/context/AuthContext.tsx
@@ -52,7 +52,7 @@ function AuthProvider({ children }: { children: React.ReactNode }) {
 
   const login = useCallback(
     async ({ email, password }: LoginUserParams) => {
-      await _loginUser({ email, password });
+      await _loginUser({ email: email.trim(), password: password.trim() });
     },
     [_loginUser],
   );


### PR DESCRIPTION
## #️⃣ 연관된 이슈

- #182 

## 🔨작업 내용

### 전송 데이터 공백 제거

로그인, 비밀번호 변경 시 전송 데이터에 `trim()`을 적용해 공백을 제거 했습니다.

### 프로필/비밀번호 변경 시 응답 데이터에 대한 모달 렌더링

프로필/비밀번호 변경 시 응답 데이터에 대한 모달을 렌더링합니다.

### 계정 관리 페이지 레이아웃 적용

계정 관리 페이지에 Container 컴포넌트를 적용했습니다.

