### PR TITLE
대쉬보드 할 일 카드 생성/삭제/수정 시 상태 업데이트

### DIFF
--- a/app/(routes)/dashboard/[dashboardId]/CreateCardButton.tsx
+++ b/app/(routes)/dashboard/[dashboardId]/CreateCardButton.tsx
@@ -1,12 +1,12 @@
 import Image from 'next/image';
-import { columnData } from './Dashboard';
+import { ColumnData } from './Dashboard';
 
 export default function CreateCardButton({
   onClick,
   id,
   title,
 }: {
-  onClick: ({ id, title }: columnData) => void;
+  onClick: ({ id, title }: ColumnData) => void;
   id: number;
   title: string;
 }) {

--- a/app/(routes)/dashboard/[dashboardId]/CreateTodoModal.tsx
+++ b/app/(routes)/dashboard/[dashboardId]/CreateTodoModal.tsx
@@ -5,6 +5,7 @@ import { TodoFormContent } from '@/_components/Modals/DashboardModal/TodoFormCon
 import GenericModal from '@/_components/Modals/GenericModal';
 import { TodoFormFooter } from '@/_components/Modals/DashboardModal/TodoFormFooter';
 import { FormDataValue } from '@/_types/todo-prop.type';
+import { CardType } from '@/_types/cards.type';
 
 interface CreateTodoModalProps {
   dashboardId: number;
@@ -14,6 +15,7 @@ interface CreateTodoModalProps {
   };
   members: Member[];
   onClose: () => void;
+  onAddCard: (columnId: number, newCard: CardType) => void;
 }
 
 export default function CreateTodoModal({
@@ -21,6 +23,7 @@ export default function CreateTodoModal({
   columnData,
   members,
   onClose,
+  onAddCard,
 }: CreateTodoModalProps) {
   const [isLoading, setIsLoading] = useState(false);
   const [formData, setFormData] = useState({
@@ -45,7 +48,7 @@ export default function CreateTodoModal({
   const handleCreateTodo = async () => {
     setIsLoading(true);
     try {
-      await createCard({
+      const response = await createCard({
         dashboardId,
         columnId: columnData.id,
         title: formData.title,
@@ -55,7 +58,7 @@ export default function CreateTodoModal({
         tags: formData.tags,
         imageUrl: formData.imageUrl,
       });
-      onClose();
+      onAddCard(columnData.id, response);
     } catch (error) {
       alert('할 일 생성에 실패했습니다.');
       console.error('할 일 생성 에러:', error);

--- a/app/(routes)/dashboard/[dashboardId]/Dashboard.tsx
+++ b/app/(routes)/dashboard/[dashboardId]/Dashboard.tsx
@@ -283,6 +283,25 @@ export default function DashBoard({ dashBoard }: { dashBoard: DashboardType }) {
     });
   };
 
+  const handleUpdateCard = (columnId: number, updatedCard: CardType) => {
+    setItemGroups((itemGroups) => {
+      const updatedItemGroups = {
+        ...itemGroups,
+        [columnId]: {
+          ...itemGroups[columnId],
+          cardData: {
+            ...itemGroups[columnId].cardData,
+            cards: itemGroups[columnId].cardData.cards.map((card) =>
+              card.id === updatedCard.id ? { ...card, ...updatedCard } : card,
+            ),
+          },
+        },
+      };
+
+      return updatedItemGroups;
+    });
+  };
+
   const handleColumnCreated = ({ id, title }: OnColumnHandlerParams) => {
     setItemGroups((prevItemGroups) => ({
       ...prevItemGroups,
@@ -402,6 +421,7 @@ export default function DashBoard({ dashBoard }: { dashBoard: DashboardType }) {
             columnTitle: title,
           }))}
           members={members?.members || []}
+          onEditCard={handleUpdateCard}
           onClose={handleCloseEditModal}
         />
       )}

--- a/app/(routes)/dashboard/[dashboardId]/Dashboard.tsx
+++ b/app/(routes)/dashboard/[dashboardId]/Dashboard.tsx
@@ -265,6 +265,24 @@ export default function DashBoard({ dashBoard }: { dashBoard: DashboardType }) {
     }
   };
 
+  const handleAddNewCard = (columnId: number, newCard: CardType) => {
+    setItemGroups((itemGroups) => {
+      const newItemGroups = {
+        ...itemGroups,
+        [columnId]: {
+          ...itemGroups[columnId],
+          cardData: {
+            cursorId: itemGroups[columnId].cardData.cursorId,
+            totalCount: itemGroups[columnId].cardData.totalCount + 1,
+            cards: [...itemGroups[columnId].cardData.cards, newCard],
+          },
+        },
+      };
+
+      return newItemGroups;
+    });
+  };
+
   const handleColumnCreated = ({ id, title }: OnColumnHandlerParams) => {
     setItemGroups((prevItemGroups) => ({
       ...prevItemGroups,
@@ -358,6 +376,7 @@ export default function DashBoard({ dashBoard }: { dashBoard: DashboardType }) {
           columnData={selectedColumn}
           members={members?.members || []}
           onClose={() => setIsCreateCardModalVisible(false)}
+          onAddCard={handleAddNewCard}
         />
       )}
 

--- a/app/(routes)/dashboard/[dashboardId]/Dashboard.tsx
+++ b/app/(routes)/dashboard/[dashboardId]/Dashboard.tsx
@@ -43,7 +43,7 @@ export type OnColumnHandlerType = ({
   title,
 }: OnColumnHandlerParams) => void;
 
-export type columnData = {
+export type ColumnData = {
   id: number;
   title: string;
 };
@@ -58,7 +58,7 @@ export default function DashBoard({ dashBoard }: { dashBoard: DashboardType }) {
   const [selectedCard, setSelecedCard] = useState<CardType | null>(null);
   const [isCardModalVisible, setIsCardModalVisible] = useState(false);
   const [isEditModalVisible, setIsEditModalVisible] = useState(false);
-  const [selectedColumn, setSelecedColumn] = useState<columnData | null>(null);
+  const [selectedColumn, setSelecedColumn] = useState<ColumnData | null>(null);
   const [isCreateCardModalVisible, setIsCreateCardModalVisible] =
     useState(false);
   const sensors = useSensors(
@@ -331,7 +331,11 @@ export default function DashBoard({ dashBoard }: { dashBoard: DashboardType }) {
     });
   };
 
-  const handleClickCreateCard = ({ id, title }: columnData) => {
+  const handleClickColumn = ({ id, title }: ColumnData) => {
+    setSelecedColumn({ id, title });
+  };
+
+  const handleClickCreateCard = ({ id, title }: ColumnData) => {
     setSelecedColumn({ id, title });
     setIsCreateCardModalVisible(true);
   };
@@ -375,6 +379,7 @@ export default function DashBoard({ dashBoard }: { dashBoard: DashboardType }) {
                 onColumnDeleted={handleColumnDeleted}
                 onClickCard={handleClickCard}
                 onClickCreateCard={handleClickCreateCard}
+                onClickColumn={handleClickColumn}
               />
             ))}
 
@@ -399,12 +404,12 @@ export default function DashBoard({ dashBoard }: { dashBoard: DashboardType }) {
         />
       )}
 
-      {isCardModalVisible && selectedCard && (
+      {isCardModalVisible && selectedCard && selectedColumn && (
         <>
           <TodoCardModal
             userId={selectedCard.assignee.id}
             cardId={selectedCard.id}
-            columnTitle={selectedCard.title}
+            columnTitle={selectedColumn.title}
             dashboardId={dashBoard.id}
             onClose={handleCloseCardModal}
             onEditClick={() => setIsEditModalVisible(true)}

--- a/app/(routes)/dashboard/[dashboardId]/Dashboard.tsx
+++ b/app/(routes)/dashboard/[dashboardId]/Dashboard.tsx
@@ -345,6 +345,26 @@ export default function DashBoard({ dashBoard }: { dashBoard: DashboardType }) {
     setIsCardModalVisible(true);
   };
 
+  const handleDeleteCard = (columnId: number, cardId: number) => {
+    setItemGroups((itemGroups) => {
+      const updatedItemGroups = {
+        ...itemGroups,
+        [columnId]: {
+          ...itemGroups[columnId],
+          cardData: {
+            ...itemGroups[columnId].cardData,
+            totalCount: itemGroups[columnId].cardData.totalCount - 1,
+            cards: itemGroups[columnId].cardData.cards.filter(
+              (card) => card.id !== cardId,
+            ),
+          },
+        },
+      };
+
+      return updatedItemGroups;
+    });
+  };
+
   const handleCloseCardModal = () => {
     setIsCardModalVisible(false);
   };
@@ -409,10 +429,11 @@ export default function DashBoard({ dashBoard }: { dashBoard: DashboardType }) {
           <TodoCardModal
             userId={selectedCard.assignee.id}
             cardId={selectedCard.id}
-            columnTitle={selectedColumn.title}
+            column={selectedColumn}
             dashboardId={dashBoard.id}
             onClose={handleCloseCardModal}
             onEditClick={() => setIsEditModalVisible(true)}
+            onDeleteCard={handleDeleteCard}
           />
         </>
       )}

--- a/app/(routes)/dashboard/[dashboardId]/Droppable.tsx
+++ b/app/(routes)/dashboard/[dashboardId]/Droppable.tsx
@@ -7,7 +7,7 @@ import CreateCardButton from './CreateCardButton';
 import Image from 'next/image';
 import { useState } from 'react';
 import EditColumnModal from '../EditColumnModal';
-import { columnData, OnColumnHandlerType } from './Dashboard';
+import { ColumnData, OnColumnHandlerType } from './Dashboard';
 
 interface DroppableProps {
   id: string;
@@ -17,7 +17,8 @@ interface DroppableProps {
   onColumnUpdated: OnColumnHandlerType;
   onColumnDeleted: OnColumnHandlerType;
   onClickCard: (card: CardType) => void;
-  onClickCreateCard: ({ id, title }: columnData) => void;
+  onClickColumn: ({ id, title }: ColumnData) => void;
+  onClickCreateCard: ({ id, title }: ColumnData) => void;
 }
 
 export default function Droppable({
@@ -28,11 +29,12 @@ export default function Droppable({
   onColumnUpdated,
   onClickCard,
   onClickCreateCard,
+  onClickColumn,
   onColumnDeleted: onColumnDelete,
 }: DroppableProps) {
   const { setNodeRef } = useDroppable({ id });
   const [isEditModalOpen, setIsEditModalOpen] = useState(false);
-
+  const numericId = Number(id);
   const handleOpenEditModal = () => {
     setIsEditModalOpen(true);
   };
@@ -41,9 +43,16 @@ export default function Droppable({
     setIsEditModalOpen(false);
   };
 
+  const handleClickColumn = ({ id, title }: ColumnData) => {
+    onClickColumn({ id, title });
+  };
+
   return (
     <SortableContext id={id} items={items} strategy={rectSortingStrategy}>
-      <div className="px-3 py-4 mobile:w-full pc:max-w-[384px]">
+      <div
+        onClick={() => handleClickColumn({ id: numericId, title })}
+        className="px-3 py-4 mobile:w-full pc:max-w-[384px]"
+      >
         <div className="border-b-2 pb-2 tablet:pb-6 pc:border-none">
           <div className="flex justify-between pb-1">
             <div className="mb-4 flex items-center gap-2">

--- a/app/(routes)/dashboard/[dashboardId]/EditTodoModal.tsx
+++ b/app/(routes)/dashboard/[dashboardId]/EditTodoModal.tsx
@@ -12,6 +12,7 @@ interface EditTodoModalProps {
   card: CardType;
   columns: Array<{ columnId: number; columnTitle: string }>;
   members: Member[] | [];
+  onEditCard: (columnId: number, updatedCard: CardType) => void;
   onClose: () => void;
 }
 
@@ -20,6 +21,7 @@ export default function EditTodoModal({
   card,
   columns,
   members,
+  onEditCard,
   onClose,
 }: EditTodoModalProps) {
   const [formData, setFormData] = useState({
@@ -47,10 +49,11 @@ export default function EditTodoModal({
   const handleEditTodo = async () => {
     setIsLoading(true);
     try {
-      await updateCard({
+      const response = await updateCard({
         cardId: card.id,
         ...formData,
       });
+      onEditCard(formData.columnId, response);
       onClose();
     } catch (error) {
       alert('할 일 수정에 실패했습니다.');

--- a/app/(routes)/dashboard/[dashboardId]/TodoCardModal.tsx
+++ b/app/(routes)/dashboard/[dashboardId]/TodoCardModal.tsx
@@ -9,23 +9,26 @@ import useIntersectionObserver from '@/_hooks/useIntersectionObserver';
 import { CardType } from '@/_types/cards.type';
 import UserProfile from '@/_components/UserProfile/UserProfile';
 import useResize from '@/utils/useResize';
+import { ColumnData } from './Dashboard';
 
 interface TodoCardModalProps {
   userId: number;
   cardId: number;
-  columnTitle: string;
+  column: ColumnData;
   dashboardId: number;
   onClose: () => void;
   onEditClick: () => void;
+  onDeleteCard: (columnId: number, cardId: number) => void;
 }
 
 export default function TodoCardModal({
   userId,
   cardId,
-  columnTitle,
+  column,
   dashboardId,
   onClose,
   onEditClick,
+  onDeleteCard,
 }: TodoCardModalProps) {
   const [cardInfo, setCardInfo] = useState<CardType | null>(null);
   const {
@@ -49,6 +52,7 @@ export default function TodoCardModal({
   const handleDeleteCard = async () => {
     try {
       await deleteCard({ cardId });
+      onDeleteCard(column.id, cardId);
       alert('카드가 삭제되었습니다.');
     } catch (error) {
       console.error('카드 삭제 오류:', error);
@@ -160,7 +164,7 @@ export default function TodoCardModal({
             <div className="flex h-full w-16 items-center gap-1 rounded-full bg-violet-8">
               <span className="ml-[6px] text-3xl text-violet-5534DA">•</span>
               <span className="mt-1 text-xs text-violet-5534DA">
-                {columnTitle}
+                {column.title}
               </span>
             </div>
             <div className="flex h-full gap-2">
@@ -312,7 +316,7 @@ export default function TodoCardModal({
                     •
                   </span>
                   <span className="mt-1 text-xs text-violet-5534DA">
-                    {columnTitle}
+                    {column.title}
                   </span>
                 </div>
                 <div className="flex gap-2">


### PR DESCRIPTION
## #️⃣ 연관된 이슈

- #190 

## 🔨작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

- [x] 할 일 카드의 정보가 변경되었을 때, 요청이 정상 처리되면 클라이언트 상태도 변경
- [x] 할 일 카드의 컬럼 태그에 카드 제목이 들어가있던 오류 수정

## 💬 리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요

- 중간에 로컬 브랜치 간 conflict가 발생해서 조금 오래 걸렸습니다 죄송합니다!
